### PR TITLE
Fix missing CSS path in service worker

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -14,7 +14,7 @@ self.addEventListener('install', (event) => {
             return cache.addAll([
                 '/',
                 '/index.html',
-                '/styles/main.css',
+                '/styles.css',
                 '/dungeons_of_enveron.html',
                 '/forbidden_creed.html',
                 '/about.html',


### PR DESCRIPTION
## Summary
- correct the stylesheet reference in `sw.js`

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6844bba70a70832783355a20c271c37f