### PR TITLE
Add parseCardTypes tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "maladum-event-cards",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node tests/parseCardTypes.test.js"
+  }
+}

--- a/tests/parseCardTypes.test.js
+++ b/tests/parseCardTypes.test.js
@@ -1,0 +1,32 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+function loadParseCardTypes() {
+  const file = path.join(__dirname, '..', 'deckbuilder.js');
+  const code = fs.readFileSync(file, 'utf8');
+  const match = code.match(/function parseCardTypes[\s\S]*?\n\}/);
+  if (!match) throw new Error('parseCardTypes function not found');
+  // Evaluate in current context so Array prototypes match
+  return (new Function(match[0] + '; return parseCardTypes;'))();
+}
+
+const parseCardTypes = loadParseCardTypes();
+
+assert.deepStrictEqual(
+  parseCardTypes('A/B+C'),
+  {
+    andGroups: [['A', 'B'], ['C']],
+    allTypes: ['A', 'B', 'C']
+  }
+);
+
+assert.deepStrictEqual(
+  parseCardTypes('Revenant/Malagaunt'),
+  {
+    andGroups: [['Revenant', 'Malagaunt']],
+    allTypes: ['Revenant', 'Malagaunt']
+  }
+);
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- set up npm test script
- add Node-based tests for the `parseCardTypes` function

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844bbb944ac8327be7a42ded4364579