### PR TITLE
Use viewport height for card item

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -215,7 +215,7 @@ body.dark-mode .card {
     max-width: 350px;
     position: relative;
     z-index: 1;
-    height: 500px;
+    height: 60vh;
     overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary
- use `height: 60vh` for `.card-item`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844bdaeaf44832785d3d71e36383c80