### PR TITLE
Add flip animations for card navigation

### DIFF
--- a/deckbuilder.js
+++ b/deckbuilder.js
@@ -334,7 +334,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     currentIndex--;
                 }
                 state.currentIndex = currentIndex;
-                showCurrentCard();
+                showCurrentCard('backward');
                 saveConfiguration();
                 trackEvent('Navigation', 'Previous Card', `Index: ${currentIndex}`);
             }
@@ -373,7 +373,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             }
 
-            showCurrentCard();
+            showCurrentCard('forward');
             updateProgressBar(); // Make sure progress bar is updated
             saveConfiguration();
             trackEvent('Navigation', 'Next Card', `Index: ${currentIndex}`);
@@ -1252,7 +1252,7 @@ function resetAvailableCards() {
 // ============================
 
 // Function to display the current card
-function showCurrentCard() {
+function showCurrentCard(direction = null) {
     const output = document.getElementById('deckOutput');
     const cardActionSection = document.getElementById('cardActionSection');
     
@@ -1273,6 +1273,15 @@ function showCurrentCard() {
         if (currentCard) {
             output.innerHTML = `<img src="cardimages/${currentCard.contents}" alt="${currentCard.card}" class="img-fluid">`;
         }
+    }
+
+    const img = output.querySelector('img');
+    if (direction && img) {
+        const className = direction === 'forward' ? 'flip-forward' : 'flip-backward';
+        img.classList.add(className);
+        img.addEventListener('animationend', () => {
+            img.classList.remove(className);
+        }, { once: true });
     }
 
     // Always update the progress bar

--- a/styles.css
+++ b/styles.css
@@ -651,6 +651,37 @@ select.form-control-lg:hover {
     }
 }
 
+/* Flip Animations */
+@keyframes flipInForward {
+    from {
+        transform: rotateY(90deg);
+        opacity: 0;
+    }
+    to {
+        transform: rotateY(0deg);
+        opacity: 1;
+    }
+}
+
+@keyframes flipInBackward {
+    from {
+        transform: rotateY(-90deg);
+        opacity: 0;
+    }
+    to {
+        transform: rotateY(0deg);
+        opacity: 1;
+    }
+}
+
+.flip-forward {
+    animation: flipInForward 0.3s ease-out;
+}
+
+.flip-backward {
+    animation: flipInBackward 0.3s ease-out;
+}
+
 /* Responsive Improvements */
 @media (max-width: 768px) {
     .app-header {


### PR DESCRIPTION
## Summary
- animate card transitions with new flip-in keyframes
- update `showCurrentCard` to accept direction and apply animation
- trigger flip animations when navigating between cards

## Testing
- `node tests/parseCardTypes.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6844c99b35a8832799e1a8b4dbadd4b7