### PR TITLE
Implement card preloading

### DIFF
--- a/deckbuilder.js
+++ b/deckbuilder.js
@@ -1087,6 +1087,9 @@ function generateDeck() {
     // Show the current card
     showCurrentCard();
 
+    // Preload the first few upcoming cards
+    preloadUpcomingCards();
+
     // Save configuration after generation
     saveConfiguration();
 
@@ -1287,9 +1290,26 @@ function showCurrentCard(direction = null) {
 
     // Always update the progress bar
     updateProgressBar();
-    
+
     // Save current state
     saveConfiguration();
+
+    // Preload upcoming card images for smoother navigation
+    preloadUpcomingCards();
+}
+
+// Function to preload upcoming card images
+function preloadUpcomingCards(count = 2) {
+    for (let i = 1; i <= count; i++) {
+        const index = currentIndex + i;
+        if (index >= 0 && index < currentDeck.length) {
+            const card = currentDeck[index];
+            if (card && card.contents) {
+                const img = new Image();
+                img.src = `cardimages/${card.contents}`;
+            }
+        }
+    }
 }
 
 // Function to display the deck

--- a/service-worker.js
+++ b/service-worker.js
@@ -17,6 +17,10 @@ const urlsToCache = [
     './maladumcards.json',
     './difficulties.json',
     './version.json',
+    './cardimages/back.jpg',
+    './cardimages/Ambush.png',
+    './cardimages/Chilling_Aura.png',
+    './cardimages/Bounty.png',
     'https://www.googletagmanager.com/gtag/js?id=' + GOOGLE_ANALYTICS_ID,
 ];
 


### PR DESCRIPTION
## Summary
- preload the next two upcoming cards for smoother navigation
- trigger preloading at deck generation and after each card view
- cache the card back and a few card images in service worker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844cbdc706c83279633d5b3f07162ef