### PR TITLE
Improve card type input rendering

### DIFF
--- a/deckbuilder.js
+++ b/deckbuilder.js
@@ -507,6 +507,8 @@ function generateCardTypeInputs() {
 
     allCardTypes.sort(); // Sort the card types alphabetically
 
+    const fragment = document.createDocumentFragment();
+
     allCardTypes.forEach(type => {
         // Adjust maxCount based on unique cards
         const uniqueCards = new Set(deckDataByType[type].map(card => card.id));
@@ -527,8 +529,10 @@ function generateCardTypeInputs() {
         `;
 
         div.innerHTML = cardHTML;
-        cardTypeInputs.appendChild(div);
+        fragment.appendChild(div);
     });
+
+    cardTypeInputs.appendChild(fragment);
 
     // Add event listeners for +/- buttons
     document.querySelectorAll('.increase-btn').forEach(button => {


### PR DESCRIPTION
## Summary
- use a DocumentFragment in `generateCardTypeInputs` to build all inputs at once

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844cd041720832787a376056b1ca818