### PR TITLE
Implement debounced saves for rapid actions

### DIFF
--- a/deckbuilder.js
+++ b/deckbuilder.js
@@ -307,7 +307,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Automatically save configuration when card counts change
     document.addEventListener('input', (event) => {
         if (event.target.matches('.card-type-input input')) {
-            saveConfiguration();
+            debouncedSaveConfiguration();
         }
     });
 
@@ -336,7 +336,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
                 state.currentIndex = currentIndex;
                 showCurrentCard('backward');
-                saveConfiguration();
+                debouncedSaveConfiguration();
                 trackEvent('Navigation', 'Previous Card', `Index: ${currentIndex}`);
             }
         });
@@ -376,7 +376,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
             showCurrentCard('forward');
             updateProgressBar(); // Make sure progress bar is updated
-            saveConfiguration();
+            debouncedSaveConfiguration();
             trackEvent('Navigation', 'Next Card', `Index: ${currentIndex}`);
         });
     } else {
@@ -537,7 +537,7 @@ function generateCardTypeInputs() {
             const input = document.getElementById(`type-${type}`);
             if (parseInt(input.value) < parseInt(input.max)) {
                 input.value = parseInt(input.value) + 1;
-                saveConfiguration(); // Save configuration after every change
+                debouncedSaveConfiguration(); // Save configuration after every change
             }
         });
     });
@@ -548,7 +548,7 @@ function generateCardTypeInputs() {
             const input = document.getElementById(`type-${type}`);
             if (parseInt(input.value) > 0) {
                 input.value = parseInt(input.value) - 1;
-                saveConfiguration(); // Save configuration after every change
+                debouncedSaveConfiguration(); // Save configuration after every change
             }
         });
     });
@@ -673,6 +673,15 @@ function updateDifficultyDetails() {
 // 6. Configuration Functions
 // ============================
 
+// Simple debounce utility to limit how often a function executes
+function debounce(fn, delay = 400) {
+    let timeout;
+    return (...args) => {
+        clearTimeout(timeout);
+        timeout = setTimeout(() => fn.apply(this, args), delay);
+    };
+}
+
 // Function to save configuration
 function saveConfiguration() {
     if (!storageUtils.isStorageAvailable()) {
@@ -731,6 +740,9 @@ function saveConfiguration() {
         console.warn('Error saving configuration:', e);
     }
 }
+
+// Debounced version used for rapid events
+const debouncedSaveConfiguration = debounce(saveConfiguration, 400);
 
 // Function to restore deck state from saved configuration
 function restoreDeckState(savedConfig) {
@@ -1292,7 +1304,7 @@ function showCurrentCard(direction = null) {
     updateProgressBar();
 
     // Save current state
-    saveConfiguration();
+    debouncedSaveConfiguration();
 
     // Preload upcoming card images for smoother navigation
     preloadUpcomingCards();


### PR DESCRIPTION
## Summary
- add a debounce utility and create `debouncedSaveConfiguration`
- throttle save calls on input changes and card navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844ccf7a31c83278d0e37abf115286c