### PR TITLE
Implement cached card type parsing

### DIFF
--- a/tests/parseCardTypes.test.js
+++ b/tests/parseCardTypes.test.js
@@ -7,8 +7,8 @@ function loadParseCardTypes() {
   const code = fs.readFileSync(file, 'utf8');
   const match = code.match(/function parseCardTypes[\s\S]*?\n\}/);
   if (!match) throw new Error('parseCardTypes function not found');
-  // Evaluate in current context so Array prototypes match
-  return (new Function(match[0] + '; return parseCardTypes;'))();
+  // Provide cache map in the evaluation context
+  return (new Function('const parseCardTypesCache = new Map();\n' + match[0] + '; return parseCardTypes;'))();
 }
 
 const parseCardTypes = loadParseCardTypes();


### PR DESCRIPTION
## Summary
- add a module-level `Map` to store parsed card types
- cache results in `parseCardTypes`
- use `parseCardTypes` when building UI selections
- adjust unit test harness for the cache

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844cce5e4c48327a8fe31949d309da7