### PR TITLE
Keep service worker version in sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "maladum-event-cards",
   "version": "1.0.0",
   "scripts": {
-    "test": "node tests/parseCardTypes.test.js"
+    "test": "node tests/parseCardTypes.test.js",
+    "build": "node scripts/update-version.js"
   }
 }

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const path = require('path');
+
+const versionFile = path.join(__dirname, '..', 'version.json');
+const swFile = path.join(__dirname, '..', 'service-worker.js');
+
+const { version } = JSON.parse(fs.readFileSync(versionFile, 'utf8'));
+let sw = fs.readFileSync(swFile, 'utf8');
+
+const newSw = sw.replace(/const APP_VERSION = '.*?';/, `const APP_VERSION = '${version}';`);
+
+if (sw !== newSw) {
+  fs.writeFileSync(swFile, newSw);
+  console.log(`Updated service-worker APP_VERSION to ${version}`);
+} else {
+  console.log('APP_VERSION already up to date');
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,6 +1,6 @@
 // Unified service worker combining caching and version logic
 const CACHE_NAME = 'maladum-event-cards-v6';
-const APP_VERSION = '2.3';
+const APP_VERSION = '2.5';
 const GOOGLE_ANALYTICS_ID = 'G-ZMTSM9B7Q7';
 
 const urlsToCache = [


### PR DESCRIPTION
## Summary
- update `APP_VERSION` constant to `2.5`
- add `scripts/update-version.js` to sync service-worker version with `version.json`
- add `build` npm script that runs the sync script

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844d0db9f588327be53778f93146873