### PR TITLE
Improve offline caching and deckbuilder utilities

### DIFF
--- a/card-utils.js
+++ b/card-utils.js
@@ -1,0 +1,33 @@
+// card-utils.js - ES module providing shared utilities
+// Utility to parse card type strings like "A/B+C" into groups
+const parseCardTypesCache = new Map();
+
+export function parseCardTypes(typeString) {
+    if (parseCardTypesCache.has(typeString)) {
+        return parseCardTypesCache.get(typeString);
+    }
+
+    const andGroups = typeString.split('+').map(group => group.trim());
+    const parsedGroups = andGroups.map(group => {
+        const orOptions = group.split('/').map(option => option.trim());
+        return orOptions;
+    });
+
+    const result = {
+        andGroups: parsedGroups,
+        allTypes: [...new Set(parsedGroups.flat())]
+    };
+
+    parseCardTypesCache.set(typeString, result);
+    return result;
+}
+
+// Simple Fisher-Yates shuffle
+export function shuffleDeck(deck) {
+    let currentIndex = deck.length;
+    while (currentIndex) {
+        const randomIndex = Math.floor(Math.random() * currentIndex--);
+        [deck[currentIndex], deck[randomIndex]] = [deck[randomIndex], deck[currentIndex]];
+    }
+    return deck;
+}

--- a/index.html
+++ b/index.html
@@ -441,7 +441,7 @@
     <script src="storage-utils.js"></script>
     <script src="dom-utils.js"></script>
     <!-- Include Deck Builder JS -->
-    <script src="deckbuilder.js"></script>
+    <script type="module" src="deckbuilder.js"></script>
 
     <!-- Add Campaign Modal -->
     <div class="modal fade" id="campaignModal" tabindex="-1" role="dialog" aria-labelledby="campaignModalLabel" aria-hidden="true">
@@ -492,34 +492,6 @@
         }
     });
 
-    // Only keep the event listener for marking cards in play
-    document.getElementById('markInPlay')?.addEventListener('click', function() {
-        const currentCard = document.getElementById('deckOutput').firstElementChild;
-        const inPlayCards = document.getElementById('inPlayCards');
-        
-        if (currentCard && inPlayCards) {
-            // Create wrapper div
-            const wrapper = document.createElement('div');
-            wrapper.className = 'mb-3 text-center';
-            
-            // Clone the card
-            const cardClone = currentCard.cloneNode(true);
-            wrapper.appendChild(cardClone);
-            
-            // Add discard button
-            const discardButton = document.createElement('button');
-            discardButton.className = 'btn btn-danger mt-2';
-            discardButton.innerHTML = '<i class="fas fa-trash"></i> Discard';
-            discardButton.onclick = function() {
-                wrapper.remove();
-                window.saveConfiguration(); // Use deckbuilder.js saveConfiguration
-            };
-            wrapper.appendChild(discardButton);
-            
-            inPlayCards.appendChild(wrapper);
-            window.saveConfiguration(); // Use deckbuilder.js saveConfiguration
-        }
-    });
     </script>
 
 </body>

--- a/tests/parseCardTypes.test.js
+++ b/tests/parseCardTypes.test.js
@@ -3,12 +3,12 @@ const fs = require('fs');
 const path = require('path');
 
 function loadParseCardTypes() {
-  const file = path.join(__dirname, '..', 'deckbuilder.js');
+  const file = path.join(__dirname, '..', 'card-utils.js');
   const code = fs.readFileSync(file, 'utf8');
-  const match = code.match(/function parseCardTypes[\s\S]*?\n\}/);
+  const match = code.match(/export function parseCardTypes[\s\S]*?\n\}/);
   if (!match) throw new Error('parseCardTypes function not found');
-  // Provide cache map in the evaluation context
-  return (new Function('const parseCardTypesCache = new Map();\n' + match[0] + '; return parseCardTypes;'))();
+  const fnBody = match[0].replace('export ', '');
+  return (new Function('const parseCardTypesCache = new Map();\n' + fnBody + '; return parseCardTypes;'))();
 }
 
 const parseCardTypes = loadParseCardTypes();


### PR DESCRIPTION
## Summary
- add new `card-utils.js` ES module with `parseCardTypes` and `shuffleDeck`
- convert `deckbuilder.js` to module and use utilities
- centralize mark-in-play and clear card actions in `deckbuilder.js`
- revise service worker to dynamically cache card images
- adjust HTML to load `deckbuilder.js` as a module and drop old script
- update unit test to read utilities file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844d4a22ba8832783f6eab2063eb6da