### PR TITLE
Improve mobile header layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -15,7 +15,7 @@
     
     <!-- Head content -->
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <title>About / FAQ - Event Cards</title>
     
     <!-- Include Bootstrap CSS with SRI -->

--- a/dungeons_of_enveron.html
+++ b/dungeons_of_enveron.html
@@ -4,7 +4,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <title>Dungeons of Enveron - Campaign Tracker</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
@@ -257,7 +257,7 @@
         </div>
         
         <div id="headerButtons" class="d-flex align-items-center">
-            <a href="about.html" class="faq-icon" title="About / FAQ">
+            <a href="about.html" class="faq-icon" title="About / FAQ" aria-label="About / FAQ">
                 <i class="fas fa-question-circle"></i>
             </a>
             

--- a/forbidden_creed.html
+++ b/forbidden_creed.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <title>The Forbidden Creed - Campaign Tracker</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
@@ -194,7 +194,7 @@
         
         <div id="headerButtons" class="d-flex align-items-center">
             <!-- FAQ Button -->
-            <a href="about.html" class="faq-icon" title="About / FAQ">
+            <a href="about.html" class="faq-icon" title="About / FAQ" aria-label="About / FAQ">
                 <i class="fas fa-question-circle"></i>
             </a>
             

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     
     <!-- Head content -->
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <title>Deck Builder</title>
     
     <!-- Include Bootstrap CSS -->
@@ -285,12 +285,12 @@
         
         <div id="headerButtons" class="d-flex align-items-center">
             <!-- Add Campaign Manager Icon -->
-            <a href="#" class="faq-icon" title="Campaign Manager" data-toggle="modal" data-target="#campaignModal">
+            <a href="#" class="faq-icon" title="Campaign Manager" aria-label="Campaign Manager" data-toggle="modal" data-target="#campaignModal">
                 <i class="fas fa-scroll"></i>
             </a>
             
             <!-- FAQ Icon -->
-            <a href="about.html" class="faq-icon" title="About / FAQ">
+            <a href="about.html" class="faq-icon" title="About / FAQ" aria-label="About / FAQ">
                 <i class="fas fa-question-circle"></i>
             </a>
 

--- a/styles.css
+++ b/styles.css
@@ -7,6 +7,11 @@
     padding: 10px;
 }
 
+/* Support devices with display cutouts */
+body {
+    padding-top: env(safe-area-inset-top);
+}
+
 /* Dark Mode Styles */
 body.dark-mode {
     background-color: var(--dark-bg);
@@ -191,6 +196,7 @@ body.dark-mode .card {
 #headerButtons {
     display: flex;
     gap: 10px; /* Space between the buttons */
+    flex-wrap: wrap; /* allow wrapping on narrow screens */
 }
 
 #headerButtons .btn {


### PR DESCRIPTION
## Summary
- add safe area padding for notches
- allow header buttons to wrap on small screens
- standardize viewport tag across all pages
- improve accessibility with aria labels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844d6833bb48327bcfab4c63efa3a84