### PR TITLE
Bump app version to 2.6

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,6 +1,6 @@
 // Unified service worker combining caching and version logic
 const CACHE_NAME = 'maladum-event-cards-v6';
-const APP_VERSION = '2.5';
+const APP_VERSION = '2.6';
 const GOOGLE_ANALYTICS_ID = 'G-ZMTSM9B7Q7';
 
 const urlsToCache = [

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-    "version": "2.5",
-    "lastUpdated": "2025-06-07"
+  "version": "2.6",
+  "lastUpdated": "2025-06-08"
 }


### PR DESCRIPTION
## Summary
- bump `version.json` to 2.6
- sync service worker version constant

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844d8ab635c832781645e188f70f4a4