### PR TITLE
Add image support to campaign pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ npm run build
 This script syncs the version inside `service-worker.js` so you only need to
 update it in one place.
 
+## Image Notes
+
+The campaign tracker pages let you attach photos from your device. Images are
+stored as Base64 data inside your browser's `localStorage`. Most browsers limit
+this storage to roughly 5&nbsp;MB, so keep images small and few in number. All
+image data stays on your device and is never uploaded anywhere.
+
 ## License
 
 This project is released under the [MIT License](LICENSE).

--- a/dungeons_of_enveron.html
+++ b/dungeons_of_enveron.html
@@ -245,6 +245,24 @@
             height: 20px;
             vertical-align: middle;
         }
+
+        .image-gallery {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            margin: 10px 0;
+        }
+
+        .image-item img {
+            max-width: 150px;
+            max-height: 150px;
+            display: block;
+        }
+
+        .image-item button {
+            display: block;
+            margin-top: 5px;
+        }
     </style>
 </head>
 <body class="dark-mode">
@@ -275,6 +293,9 @@
             <textarea id="notesTextarea" placeholder="Add your campaign notes here..."></textarea>
         </div>
     </div>
+
+    <input id="imageInput" type="file" accept="image/*" capture="environment">
+    <div id="imageGallery" class="image-gallery"></div>
 
     <div class="campaign-container">
         <div class="campaign-card">
@@ -525,6 +546,11 @@
         const notesContent = document.getElementById('notesContent');
         const notesTextarea = document.getElementById('notesTextarea');
         const collapseIcon = document.querySelector('.collapse-icon');
+        const imageInput = document.getElementById('imageInput');
+        const imageGallery = document.getElementById('imageGallery');
+        let images = [];
+
+        imageInput.addEventListener('change', handleImageUpload);
 
         function toggleNotes() {
             notesContent.classList.toggle('visible');
@@ -543,6 +569,39 @@
             });
         });
 
+        function handleImageUpload(event) {
+            Array.from(event.target.files).forEach(file => {
+                const reader = new FileReader();
+                reader.onload = e => {
+                    images.push(e.target.result);
+                    renderGallery();
+                    saveState();
+                };
+                reader.readAsDataURL(file);
+            });
+            imageInput.value = '';
+        }
+
+        function renderGallery() {
+            imageGallery.innerHTML = '';
+            images.forEach((src, index) => {
+                const wrapper = document.createElement('div');
+                wrapper.className = 'image-item';
+                const img = document.createElement('img');
+                img.src = src;
+                const btn = document.createElement('button');
+                btn.textContent = 'Remove';
+                btn.addEventListener('click', () => {
+                    images.splice(index, 1);
+                    renderGallery();
+                    saveState();
+                });
+                wrapper.appendChild(img);
+                wrapper.appendChild(btn);
+                imageGallery.appendChild(wrapper);
+            });
+        }
+
         function saveState() {
             try {
                 const state = {
@@ -555,7 +614,8 @@
                     numberedCircles: Array.from(document.querySelectorAll('.numbered-circle')).map(circle => circle.style.backgroundColor === 'black'),
                     inputs: Array.from(document.querySelectorAll('.input-field')).map(input => input.value),
                     notes: notesTextarea.value,
-                    notesVisible: notesContent.classList.contains('visible')
+                    notesVisible: notesContent.classList.contains('visible'),
+                    images
                 };
                 storageUtils.saveState('dungeonState', state);
             } catch (e) {
@@ -610,6 +670,9 @@
                     document.querySelectorAll('.malagaunt-checkbox').forEach((cb, i) => {
                         cb.style.backgroundColor = state.malagauntTrack[i] ? 'black' : '';
                     });
+
+                    images = state.images || [];
+                    renderGallery();
                 }
             } catch (e) {
                 console.warn('Error loading state:', e);

--- a/forbidden_creed.html
+++ b/forbidden_creed.html
@@ -181,6 +181,24 @@
             color: #333;
             text-shadow: 0 0 2px rgba(255, 255, 255, 0.5);
         }
+
+        .image-gallery {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            margin: 10px 0;
+        }
+
+        .image-item img {
+            max-width: 150px;
+            max-height: 150px;
+            display: block;
+        }
+
+        .image-item button {
+            display: block;
+            margin-top: 5px;
+        }
     </style>
 </head>
 <body class="dark-mode">
@@ -213,6 +231,9 @@
             <textarea id="notesTextarea" placeholder="Add your campaign notes here..."></textarea>
         </div>
     </div>
+
+    <input id="imageInput" type="file" accept="image/*" capture="environment">
+    <div id="imageGallery" class="image-gallery"></div>
 
     <div class="campaign-container">
         <!-- Page 1 -->
@@ -404,6 +425,11 @@
         const notesTextarea = document.getElementById('notesTextarea');
         const collapseIcon = document.querySelector('.collapse-icon');
         const checkboxes = document.querySelectorAll('.checkbox');
+        const imageInput = document.getElementById('imageInput');
+        const imageGallery = document.getElementById('imageGallery');
+        let images = [];
+
+        imageInput.addEventListener('change', handleImageUpload);
 
         // Function to toggle notes visibility
         function toggleNotes() {
@@ -420,13 +446,47 @@
             });
         });
 
+        function handleImageUpload(event) {
+            Array.from(event.target.files).forEach(file => {
+                const reader = new FileReader();
+                reader.onload = e => {
+                    images.push(e.target.result);
+                    renderGallery();
+                    saveState();
+                };
+                reader.readAsDataURL(file);
+            });
+            imageInput.value = '';
+        }
+
+        function renderGallery() {
+            imageGallery.innerHTML = '';
+            images.forEach((src, index) => {
+                const wrapper = document.createElement('div');
+                wrapper.className = 'image-item';
+                const img = document.createElement('img');
+                img.src = src;
+                const btn = document.createElement('button');
+                btn.textContent = 'Remove';
+                btn.addEventListener('click', () => {
+                    images.splice(index, 1);
+                    renderGallery();
+                    saveState();
+                });
+                wrapper.appendChild(img);
+                wrapper.appendChild(btn);
+                imageGallery.appendChild(wrapper);
+            });
+        }
+
         function saveState() {
             try {
                 const state = {
                     checkboxes: Array.from(document.querySelectorAll('.checkbox')).map(cb => cb.style.backgroundColor === 'black'),
                     inputs: Array.from(document.querySelectorAll('.input-field')).map(input => input.value),
                     notes: notesTextarea.value,
-                    notesVisible: notesContent.classList.contains('visible')
+                    notesVisible: notesContent.classList.contains('visible'),
+                    images
                 };
                 storageUtils.saveState('forbiddenCreedState', state);
             } catch (e) {
@@ -456,6 +516,9 @@
                             checkboxes[index].style.backgroundColor = '#333';
                         }
                     });
+
+                    images = state.images || [];
+                    renderGallery();
                 }
             } catch (e) {
                 console.warn('Error loading state:', e);


### PR DESCRIPTION
## Summary
- allow capturing photos in both campaign trackers
- persist image data in localStorage
- show uploaded images with option to remove them
- document local image storage limits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844deebeb24832789c02d8a78d1e411