### PR TITLE
Implement update check on about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -164,6 +164,18 @@
     <!-- <script src="deckbuilder.js"></script> -->
 
     <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('./service-worker.js');
+        });
+
+        navigator.serviceWorker.addEventListener('message', event => {
+          if (event.data.type === 'NEW_VERSION') {
+            showUpdateNotification(event.data.version);
+          }
+        });
+      }
+
       function showUpdateNotification(newVersion) {
         const updateModal = `
           <div class="modal fade" id="updateModal" tabindex="-1" role="dialog" aria-labelledby="updateModalLabel" aria-hidden="true">
@@ -231,6 +243,12 @@
             fetchAndCompare(event.data);
           };
           navigator.serviceWorker.controller.postMessage('GET_VERSION', [channel.port2]);
+
+          navigator.serviceWorker.getRegistration().then(reg => {
+            if (reg) {
+              reg.update();
+            }
+          });
         } else {
           fetchAndCompare(null);
         }


### PR DESCRIPTION
## Summary
- register service worker on the About page
- handle service worker update messages
- trigger a service worker update when checking for a new version

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844e42a3b64832790c585c31ce644e1