### PR TITLE
Refactor update notification

### DIFF
--- a/about.html
+++ b/about.html
@@ -163,6 +163,8 @@
     <!-- Include Deck Builder JS (if any specific scripts needed for about.html) -->
     <!-- <script src="deckbuilder.js"></script> -->
 
+    <script type="module" src="update-utils.js"></script>
+
     <script>
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
@@ -176,50 +178,6 @@
         });
       }
 
-      function showUpdateNotification(newVersion) {
-        const updateModal = `
-          <div class="modal fade" id="updateModal" tabindex="-1" role="dialog" aria-labelledby="updateModalLabel" aria-hidden="true">
-              <div class="modal-dialog modal-dialog-centered" role="document">
-                  <div class="modal-content bg-dark text-white">
-                      <div class="modal-header">
-                          <h5 class="modal-title" id="updateModalLabel">New Version Available</h5>
-                          <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close">
-                              <span aria-hidden="true">&times;</span>
-                          </button>
-                      </div>
-                      <div class="modal-body">
-                          <p>A new version (${newVersion}) of the app is available.</p>
-                          <p>Update now to get the latest features and improvements.</p>
-                      </div>
-                      <div class="modal-footer">
-                          <button type="button" class="btn btn-secondary" data-dismiss="modal">Later</button>
-                          <button type="button" class="btn btn-primary" id="updateNowButton">Update Now</button>
-                      </div>
-                  </div>
-              </div>
-          </div>`;
-
-        const existingModal = document.getElementById('updateModal');
-        if (existingModal) {
-          existingModal.remove();
-        }
-
-        document.body.insertAdjacentHTML('beforeend', updateModal);
-        const modal = $('#updateModal');
-        modal.modal('show');
-
-        document.getElementById('updateNowButton').addEventListener('click', () => {
-          if ('caches' in window) {
-            caches.keys().then(cacheNames => {
-              return Promise.all(cacheNames.map(cacheName => caches.delete(cacheName)));
-            }).then(() => {
-              window.location.reload();
-            });
-          } else {
-            window.location.reload();
-          }
-        });
-      }
 
       document.getElementById('checkUpdateBtn').addEventListener('click', () => {
         const fetchAndCompare = installedVersion => {

--- a/deckbuilder.js
+++ b/deckbuilder.js
@@ -1,6 +1,7 @@
 // deckbuilder.js
 // Requires storage-utils.js for persistence helpers
 import { parseCardTypes, shuffleDeck } from './card-utils.js';
+import { showUpdateNotification } from './update-utils.js';
 
 // Toggle verbose logging
 const DEBUG = false;
@@ -39,56 +40,6 @@ if ('serviceWorker' in navigator) {
     });
 }
 
-// Function to show an update notification to the user
-function showUpdateNotification(newVersion) {
-    const updateModal = `
-        <div class="modal fade" id="updateModal" tabindex="-1" role="dialog" aria-labelledby="updateModalLabel" aria-hidden="true">
-            <div class="modal-dialog modal-dialog-centered" role="document">
-                <div class="modal-content bg-dark text-white">
-                    <div class="modal-header">
-                        <h5 class="modal-title" id="updateModalLabel">New Version Available</h5>
-                        <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                    </div>
-                    <div class="modal-body">
-                        <p>A new version (${newVersion}) of the app is available.</p>
-                        <p>Update now to get the latest features and improvements.</p>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Later</button>
-                        <button type="button" class="btn btn-primary" id="updateNowButton">Update Now</button>
-                    </div>
-                </div>
-            </div>
-        </div>
-    `;
-    
-    // Remove existing update modal if present
-    const existingModal = document.getElementById('updateModal');
-    if (existingModal) {
-        existingModal.remove();
-    }
-    
-    document.body.insertAdjacentHTML('beforeend', updateModal);
-    const modal = $('#updateModal');
-    modal.modal('show');
-
-    document.getElementById('updateNowButton').addEventListener('click', () => {
-        // Clear cache and reload
-        if ('caches' in window) {
-            caches.keys().then(cacheNames => {
-                return Promise.all(
-                    cacheNames.map(cacheName => caches.delete(cacheName))
-                );
-            }).then(() => {
-                window.location.reload();
-            });
-        } else {
-            window.location.reload();
-        }
-    });
-}
 
 // ============================
 // 2. Global Variables and Constants

--- a/service-worker.js
+++ b/service-worker.js
@@ -8,6 +8,7 @@ const urlsToCache = [
     './index.html',
     './styles.css',
     './deckbuilder.js',
+    './update-utils.js',
     './card-utils.js',
     './dungeons_of_enveron.html',
     './forbidden_creed.html',

--- a/update-utils.js
+++ b/update-utils.js
@@ -1,0 +1,51 @@
+export function showUpdateNotification(newVersion) {
+    const updateModal = `
+        <div class="modal fade" id="updateModal" tabindex="-1" role="dialog" aria-labelledby="updateModalLabel" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered" role="document">
+                <div class="modal-content bg-dark text-white">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="updateModalLabel">New Version Available</h5>
+                        <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                    <div class="modal-body">
+                        <p>A new version (${newVersion}) of the app is available.</p>
+                        <p>Update now to get the latest features and improvements.</p>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Later</button>
+                        <button type="button" class="btn btn-primary" id="updateNowButton">Update Now</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    `;
+
+    const existingModal = document.getElementById('updateModal');
+    if (existingModal) {
+        existingModal.remove();
+    }
+
+    document.body.insertAdjacentHTML('beforeend', updateModal);
+    const modal = $('#updateModal');
+    modal.modal('show');
+
+    document.getElementById('updateNowButton').addEventListener('click', () => {
+        if ('caches' in window) {
+            caches.keys().then(cacheNames => {
+                return Promise.all(
+                    cacheNames.map(cacheName => caches.delete(cacheName))
+                );
+            }).then(() => {
+                window.location.reload();
+            });
+        } else {
+            window.location.reload();
+        }
+    });
+}
+
+if (typeof window !== 'undefined') {
+    window.showUpdateNotification = showUpdateNotification;
+}


### PR DESCRIPTION
## Summary
- move update notification logic to new `update-utils.js`
- import helper in `deckbuilder.js`
- reuse helper from `about.html`
- cache new script in service worker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844e5b9b5688327b127ecac8fcec5ed