### PR TITLE
Remove buy me a coffee links from campaign pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -10,9 +10,6 @@
       gtag('config', 'G-ZMTSM9B7Q7');
     </script>
     
-    <!-- Buy Me a Coffee Button -->
-    
-    
     <!-- Head content -->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
@@ -57,13 +54,7 @@
                 <i class="fas fa-home"></i>
             </a>
 
-            <!-- Buy Me a Coffee Button -->
-            <div class="bmc-button-container ml-3">
-                <script type="text/javascript" src="https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js" data-name="bmc-button" data-slug="barryrodics" data-color="#000000" data-emoji="🎲" data-font="Cookie" data-text="Buy me a coffee" data-outline-color="#ffffff" data-font-color="#ffffff" data-coffee-color="#FFDD00"></script>
-            </div>
-
             <button id="checkUpdateBtn" class="btn btn-info ml-3">Check for Updates</button>
-        </div>
         </div>
     </header>
     

--- a/dungeons_of_enveron.html
+++ b/dungeons_of_enveron.html
@@ -313,9 +313,6 @@
                 <i class="fas fa-question-circle"></i>
             </a>
             
-            <div class="bmc-button-container ml-3">
-                <script type="text/javascript" src="https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js" data-name="bmc-button" data-slug="barryrodics" data-color="#000000" data-emoji="🎲" data-font="Cookie" data-text="Buy me a coffee" data-outline-color="#ffffff" data-font-color="#ffffff" data-coffee-color="#FFDD00"></script>
-            </div>
         </div>
     </header>
 

--- a/forbidden_creed.html
+++ b/forbidden_creed.html
@@ -250,10 +250,6 @@
                 <i class="fas fa-question-circle"></i>
             </a>
             
-            <!-- Buy Me a Coffee Button -->
-            <div class="bmc-button-container ml-3">
-                <script type="text/javascript" src="https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js" data-name="bmc-button" data-slug="barryrodics" data-color="#000000" data-emoji="🎲" data-font="Cookie" data-text="Buy me a coffee" data-outline-color="#ffffff" data-font-color="#ffffff" data-coffee-color="#FFDD00"></script>
-            </div>
         </div>
     </header>
 


### PR DESCRIPTION
## Summary
- remove Buy Me a Coffee from `about`, `dungeons_of_enveron`, and `forbidden_creed`
- clean up stray markup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844ea1052948327b15f841ba656d05b