### PR TITLE
Switch project to Bootstrap 5

### DIFF
--- a/about.html
+++ b/about.html
@@ -15,13 +15,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <title>About / FAQ - Event Cards</title>
     
-    <!-- Include Bootstrap CSS with SRI -->
-    <link 
-      href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.2/css/bootstrap.min.css" 
-      rel="stylesheet" 
-      integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z" 
-      crossorigin="anonymous"
-    >
+    <!-- Include Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     
     <!-- Include Font Awesome CSS for Icons with Correct SRI from cdnjs -->
     <link
@@ -130,26 +125,8 @@
         <a href="index.html" class="btn btn-primary mb-4">Back to Deck Builder</a>
     </div>
 
-    <!-- Include jQuery JS with SRI -->
-    <script 
-      src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js" 
-      integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" 
-      crossorigin="anonymous">
-    </script>
-    
-    <!-- Include Popper.js with SRI -->
-    <script 
-      src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.16.1/umd/popper.min.js" 
-      integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" 
-      crossorigin="anonymous">
-    </script>
-    
-    <!-- Include Bootstrap JS with SRI -->
-    <script 
-      src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.2/js/bootstrap.min.js" 
-      integrity="sha384-B4gt1jrGC7Jh4AgTPSdUtOBvfO8shuf57BaghqFfPlYxofvL8/KUEfYiJOMMV+rV" 
-      crossorigin="anonymous">
-    </script>
+    <!-- Include Bootstrap JS -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 
     <!-- Include Deck Builder JS (if any specific scripts needed for about.html) -->
     <!-- <script src="deckbuilder.js"></script> -->

--- a/deckbuilder.js
+++ b/deckbuilder.js
@@ -1052,9 +1052,13 @@ function generateDeck() {
     trackEvent('Deck', 'Generate', `Games: ${selectedGames.join(', ')}`, currentDeck.length);
 
     // Collapse the configuration sections (optional)
-    $('#gameCheckboxes').collapse('hide');
-    $('#scenarioConfig').collapse('hide');
-    $('#cardTypeSection').collapse('hide');
+    ['gameCheckboxes', 'scenarioConfig', 'cardTypeSection'].forEach(id => {
+        const el = document.getElementById(id);
+        if (el) {
+            const collapse = bootstrap.Collapse.getOrCreateInstance(el);
+            collapse.hide();
+        }
+    });
 }
 
 // Function to select cards by type considering '+' and '/'
@@ -1685,8 +1689,8 @@ function showToast(message) {
 
     const closeButton = document.createElement('button');
     closeButton.type = 'button';
-    closeButton.classList.add('ml-auto', 'mb-1', 'close');
-    closeButton.setAttribute('data-dismiss', 'toast');
+    closeButton.classList.add('ms-auto', 'mb-1', 'btn-close');
+    closeButton.setAttribute('data-bs-dismiss', 'toast');
     closeButton.setAttribute('aria-label', 'Close');
     closeButton.innerHTML = '<span aria-hidden="true">&times;</span>';
     toastBody.appendChild(closeButton);
@@ -1694,9 +1698,10 @@ function showToast(message) {
     toast.appendChild(toastBody);
     toastContainer.appendChild(toast);
 
-    // Automatically remove the toast after 3 seconds
+    const bsToast = new bootstrap.Toast(toast);
+    bsToast.show();
     setTimeout(() => {
-        $(toast).toast('hide');
+        bsToast.hide();
         toast.addEventListener('hidden.bs.toast', () => {
             toast.remove();
         });
@@ -1731,7 +1736,9 @@ function trackEvent(eventCategory, eventAction, eventLabel = null, eventValue = 
 // Function to enhance buttons (e.g., tooltips)
 function enhanceButtons() {
     // Initialize any tooltips or other UI enhancements here
-    $('[data-toggle="tooltip"]').tooltip();
+    document.querySelectorAll('[data-toggle="tooltip"], [data-bs-toggle="tooltip"]').forEach(el => {
+        new bootstrap.Tooltip(el);
+    });
 }
 
 // Function to toggle Sentry Rules options

--- a/dungeons_of_enveron.html
+++ b/dungeons_of_enveron.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <title>Dungeons of Enveron - Campaign Tracker</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
     <link rel="icon" href="logos/gameicon.jpg" type="image/jpeg">
     <style>

--- a/forbidden_creed.html
+++ b/forbidden_creed.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <title>The Forbidden Creed - Campaign Tracker</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
     <link rel="icon" href="logos/gameicon.jpg" type="image/jpeg">
     <style>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
     <title>Deck Builder</title>
     
     <!-- Include Bootstrap CSS -->
-    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     
     <!-- Include Font Awesome CSS for Icons -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-iecdLmaskl7CVkqkXNQ/ZH/XLlvWZOJyj7Yy7tcenmpD1ypASozpmT/E0iPtmFIB46ZmdtAc9eNBvH0H/ZpiBw==" crossorigin="anonymous">
@@ -285,7 +285,7 @@
         
         <div id="headerButtons" class="d-flex align-items-center">
             <!-- Add Campaign Manager Icon -->
-            <a href="#" class="faq-icon" title="Campaign Manager" aria-label="Campaign Manager" data-toggle="modal" data-target="#campaignModal">
+            <a href="#" class="faq-icon" title="Campaign Manager" aria-label="Campaign Manager" data-bs-toggle="modal" data-bs-target="#campaignModal">
                 <i class="fas fa-scroll"></i>
             </a>
             
@@ -306,7 +306,7 @@
             <!-- Game Selection -->
             <section id="gameSelection" class="mb-4">
                 <div class="section-header">
-                    <button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#gameCheckboxes" aria-expanded="false" aria-controls="gameCheckboxes">
+                    <button class="btn btn-link collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#gameCheckboxes" aria-expanded="false" aria-controls="gameCheckboxes">
                         <i class="fas fa-chevron-down mr-2"></i>Select Games
                     </button>
                 </div>
@@ -318,7 +318,7 @@
             <!-- Card Type Selection and Scenario Config -->
             <section id="cardTypeSection" class="mb-4">
                 <div class="section-header">
-                    <button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#cardTypeContent" aria-expanded="false" aria-controls="cardTypeContent">
+                    <button class="btn btn-link collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#cardTypeContent" aria-expanded="false" aria-controls="cardTypeContent">
                         <i class="fas fa-chevron-down mr-2"></i>Configure Deck
                     </button>
                 </div>
@@ -429,10 +429,8 @@
         </div>
     </div>
 
-    <!-- Include Bootstrap JS and dependencies -->
-    <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <!-- Include Bootstrap JS -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 
     <script src="storage-utils.js"></script>
     <script src="dom-utils.js"></script>
@@ -445,9 +443,7 @@
             <div class="modal-content bg-dark text-white">
                 <div class="modal-header">
                     <h5 class="modal-title" id="campaignModalLabel">Campaign Manager</h5>
-                    <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
+                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
                     <div class="campaign-list">

--- a/update-utils.js
+++ b/update-utils.js
@@ -5,16 +5,14 @@ export function showUpdateNotification(newVersion) {
                 <div class="modal-content bg-dark text-white">
                     <div class="modal-header">
                         <h5 class="modal-title" id="updateModalLabel">New Version Available</h5>
-                        <button type="button" class="close text-white" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
+                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
                         <p>A new version (${newVersion}) of the app is available.</p>
                         <p>Update now to get the latest features and improvements.</p>
                     </div>
                     <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Later</button>
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Later</button>
                         <button type="button" class="btn btn-primary" id="updateNowButton">Update Now</button>
                     </div>
                 </div>
@@ -28,8 +26,9 @@ export function showUpdateNotification(newVersion) {
     }
 
     document.body.insertAdjacentHTML('beforeend', updateModal);
-    const modal = $('#updateModal');
-    modal.modal('show');
+    const modalEl = document.getElementById('updateModal');
+    const modal = new bootstrap.Modal(modalEl);
+    modal.show();
 
     document.getElementById('updateNowButton').addEventListener('click', () => {
         if ('caches' in window) {


### PR DESCRIPTION
## Summary
- drop jQuery dependency and upgrade CDN links to Bootstrap 5
- rewrite jQuery collapse, toast, modal and tooltip usage with Bootstrap 5 APIs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846c52ce5d8832790d7aa98d3c206c3