### PR TITLE
Add card click navigation

### DIFF
--- a/deckbuilder.js
+++ b/deckbuilder.js
@@ -297,38 +297,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const nextCardButton = domUtils.getEl('nextCard');
     if (nextCardButton) {
-        nextCardButton.addEventListener('click', () => {
-            // Move the current card to the discard pile if it's not the starting card back
-            if (currentIndex >= 0 && currentIndex < currentDeck.length) {
-                discardPile.push(currentDeck[currentIndex]);
+        nextCardButton.addEventListener('click', advanceToNextCard);
+    }
+
+    const deckOutput = domUtils.getEl('deckOutput');
+    if (deckOutput) {
+        deckOutput.addEventListener('click', (e) => {
+            if (e.target.tagName === 'IMG' && !e.target.closest('#clearActiveCard')) {
+                advanceToNextCard();
             }
-
-            currentIndex++;
-            state.currentIndex = currentIndex;
-
-            if (currentIndex >= currentDeck.length) {
-                if (discardPile.length > 0) {
-                    // Reshuffle the discard pile to form a new deck
-                    currentDeck = shuffleDeck(discardPile);
-                    state.initialDeckSize = currentDeck.length;
-                    discardPile = [];
-                    currentIndex = -1; // Reset to start of new deck
-                    state.currentIndex = currentIndex;
-                    showToast('Deck reshuffled from discard pile.');
-                    trackEvent('Navigation', 'Reshuffle Deck', `Cards: ${state.initialDeckSize}`);
-                } else {
-                    // No more cards left to draw
-                    showToast('No more cards in the deck.');
-                    currentIndex--; // Stay at the last card
-                    state.currentIndex = currentIndex;
-                    return;
-                }
-            }
-
-            showCurrentCard('forward');
-            updateProgressBar(); // Make sure progress bar is updated
-            debouncedSaveConfiguration();
-            trackEvent('Navigation', 'Next Card', `Index: ${currentIndex}`);
         });
     }
 
@@ -1342,6 +1319,41 @@ function updateProgressBar() {
         deckLength: currentDeck.length,
         percentage: progressPercentage
     });
+}
+
+// Function to advance to the next card (used by button and card click)
+function advanceToNextCard() {
+    // Move the current card to the discard pile if it's not the starting card back
+    if (currentIndex >= 0 && currentIndex < currentDeck.length) {
+        discardPile.push(currentDeck[currentIndex]);
+    }
+
+    currentIndex++;
+    state.currentIndex = currentIndex;
+
+    if (currentIndex >= currentDeck.length) {
+        if (discardPile.length > 0) {
+            // Reshuffle the discard pile to form a new deck
+            currentDeck = shuffleDeck(discardPile);
+            state.initialDeckSize = currentDeck.length;
+            discardPile = [];
+            currentIndex = -1; // Reset to start of new deck
+            state.currentIndex = currentIndex;
+            showToast('Deck reshuffled from discard pile.');
+            trackEvent('Navigation', 'Reshuffle Deck', `Cards: ${state.initialDeckSize}`);
+        } else {
+            // No more cards left to draw
+            showToast('No more cards in the deck.');
+            currentIndex--; // Stay at the last card
+            state.currentIndex = currentIndex;
+            return;
+        }
+    }
+
+    showCurrentCard('forward');
+    updateProgressBar();
+    debouncedSaveConfiguration();
+    trackEvent('Navigation', 'Next Card', `Index: ${currentIndex}`);
 }
 
 // ============================

--- a/styles.css
+++ b/styles.css
@@ -504,6 +504,7 @@ body.dark-mode .btn {
     max-width: 100%;
     height: auto;
     transition: transform 0.3s ease;
+    cursor: pointer;
 }
 
 #deckOutput img:hover {
@@ -940,6 +941,7 @@ select.form-control-lg:hover {
         max-width: 100%;
         height: auto;
         touch-action: manipulation;
+        cursor: pointer;
     }
 
     /* Improve mobile navigation */


### PR DESCRIPTION
## Summary
- add advanceToNextCard function and reuse for button and card click
- attach click handler on deck output to go to next card
- show pointer cursor on card images

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dfbbe2524832799dfa276d718a7f1