### PR TITLE
Fix Sentry introduction updates deck arrays

### DIFF
--- a/deckbuilder.js
+++ b/deckbuilder.js
@@ -2025,6 +2025,11 @@ function introduceSentryCards() {
         ...updatedRemainingCards
     ];
 
+    // Sync deck arrays
+    state.deck.main = currentDeck;        // Treat Sentry cards as regular
+    state.deck.special = [];              // Clear special deck to keep order
+    state.deck.combined = currentDeck;
+
     // Clear the Sentry deck as it's now been used
     const sentryCount = sentryDeck.length;
     sentryDeck = [];


### PR DESCRIPTION
## Summary
- sync deck arrays when introducing Sentry cards
- treat Sentry cards as regular by adding them to the main deck

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866346523b483279691a8b31fa52f91