### PR TITLE
Change shuffleAnywhere to reveal previous card

### DIFF
--- a/cardActions.md
+++ b/cardActions.md
@@ -13,7 +13,7 @@ This action takes the current card and shuffles it randomly back into the remain
 **Behavior:**
 - The current card is removed from its position
 - The card is inserted at a random position among the remaining undrawn cards
-- The next card in the sequence is then revealed
+- The previous card in the sequence is then revealed
 
 **Example Use Case:**  
 When a threat appears that your party manages to drive away temporarily, but might return later in the expedition.

--- a/deckbuilder.js
+++ b/deckbuilder.js
@@ -1568,7 +1568,7 @@ const cardActions = {
         const cardId = card.id;
 
         // 1. Remove the card from currentDeck.
-        // currentDeck[currentIndex] now points to the card that should be revealed next.
+        // currentDeck[currentIndex] now points to the card that used to be before it.
         currentDeck.splice(currentIndex, 1);
 
         // (Original state.deck.main/special manipulation removed here)
@@ -1583,11 +1583,13 @@ const cardActions = {
         // 3. Synchronize derived deck states
         synchronizeDeckState();
 
-        // 4. The card that was at currentDeck[currentIndex] (after splice, before re-insertion) is the next card.
-        //    No change to the global `currentIndex` value is needed before calling showCurrentCard.
-        state.currentIndex = currentIndex; // Sync state with the global currentIndex which is now correct.
+        // 4. Reveal the previous card in the sequence.
+        if (currentIndex > 0) {
+            currentIndex--;
+        }
+        state.currentIndex = currentIndex; // Sync state with the global currentIndex.
 
-        showCurrentCard();
+        showCurrentCard('backward');
         saveConfiguration();
 
         return `Card "${card.card}" shuffled back into the deck.`;


### PR DESCRIPTION
## Summary
- reveal the previous card when shuffling into the remaining deck
- document new behavior in cardActions.md

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a6ef2a9e08327b0d238842d499f3f