### PR TITLE
Add shuffleDeck tests and parseCardTypes edge-case coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "maladum-event-cards",
   "version": "1.0.0",
   "scripts": {
-    "test": "node tests/parseCardTypes.test.js",
+    "test": "node tests/parseCardTypes.test.js && node tests/shuffleDeck.test.js",
     "build": "node scripts/update-version.js"
   }
 }

--- a/tests/parseCardTypes.test.js
+++ b/tests/parseCardTypes.test.js
@@ -29,4 +29,20 @@ assert.deepStrictEqual(
   }
 );
 
+assert.deepStrictEqual(
+  parseCardTypes(''),
+  {
+    andGroups: [['']],
+    allTypes: ['']
+  }
+);
+
+assert.deepStrictEqual(
+  parseCardTypes('A//B'),
+  {
+    andGroups: [['A', '', 'B']],
+    allTypes: ['A', '', 'B']
+  }
+);
+
 console.log('All tests passed.');

--- a/tests/shuffleDeck.test.js
+++ b/tests/shuffleDeck.test.js
@@ -1,0 +1,29 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+function loadShuffleDeck() {
+  const file = path.join(__dirname, '..', 'card-utils.js');
+  const code = fs.readFileSync(file, 'utf8');
+  const match = code.match(/export function shuffleDeck[\s\S]*?\n\}/);
+  if (!match) throw new Error('shuffleDeck function not found');
+  const fnBody = match[0].replace('export ', '');
+  return (new Function(fnBody + '; return shuffleDeck;'))();
+}
+
+const shuffleDeck = loadShuffleDeck();
+
+const originalDeck = [1, 2, 3, 4, 5];
+const mockValues = [0.1, 0.2, 0.3, 0.4, 0.5];
+let call = 0;
+const originalRandom = Math.random;
+Math.random = () => mockValues[call++];
+
+const shuffledDeck = shuffleDeck([...originalDeck]);
+Math.random = originalRandom;
+
+assert.strictEqual(shuffledDeck.length, originalDeck.length);
+assert.deepStrictEqual([...shuffledDeck].sort(), [...originalDeck].sort());
+assert.notDeepStrictEqual(shuffledDeck, originalDeck);
+
+console.log('shuffleDeck tests passed.');


### PR DESCRIPTION
## Summary
- add deterministic shuffleDeck unit test
- extend parseCardTypes tests to cover empty and malformed strings
- run both test files via npm test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896216298c88327a15a1d6216b90962