### PR TITLE
Adjust card item sizing for cleaner layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -218,16 +218,19 @@ body.dark-mode .card {
     text-align: center;
     transition: opacity 0.5s ease-in-out;
     margin: 0 auto;
-    max-width: 350px;
+    max-width: 360px;
     position: relative;
     z-index: 1;
-    height: 60vh;
+    aspect-ratio: 2 / 3;
+    height: auto;
     overflow: hidden;
+    display: flex;
+    align-items: center;
 }
 
 .card-image {
-    max-width: 100%;
-    max-height: 100%;
+    width: 100%;
+    height: 100%;
     object-fit: contain;
     margin: 0 auto;
     display: block;


### PR DESCRIPTION
## Summary
- keep card items constrained to a consistent aspect ratio instead of stretching to viewport height
- center card contents with flex alignment and scale images to fill their containers without distortion

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c93796b588327a52a3af81e12b73c)