### PR TITLE
Add card search UI for available cards

### DIFF
--- a/events.js
+++ b/events.js
@@ -7,8 +7,10 @@ import { state } from './state.js';
 import { trackEvent, debounce } from './app-utils.js';
 import { saveConfiguration } from './config-manager.js';
 import { setupManualUpdateCheck } from './update-utils.js';
+import { updateCardSearchResults } from './ui-manager.js';
 
 const debouncedSaveConfiguration = debounce(saveConfiguration, 400);
+const debouncedCardSearch = debounce((value) => updateCardSearchResults(value), 150);
 
 export function setupEventListeners() {
     // Generate Deck
@@ -110,6 +112,13 @@ export function setupEventListeners() {
             updateInPlayCardsDisplay();
             debouncedSaveConfiguration();
             trackEvent('Card Status', 'Clear In Play', null);
+        });
+    }
+
+    const cardSearchInput = document.getElementById('cardSearchInput');
+    if (cardSearchInput) {
+        cardSearchInput.addEventListener('input', (e) => {
+            debouncedCardSearch(e.target.value);
         });
     }
 

--- a/index.html
+++ b/index.html
@@ -151,6 +151,20 @@
                     </div>
                 </section>
 
+                <!-- Card Search -->
+                <section id="cardSearchSection" class="mb-4">
+                    <div class="section-header">
+                        <h3 class="mb-0"><i class="fas fa-search mr-2 fs-5"></i> Search Cards</h3>
+                    </div>
+                    <div class="mt-3">
+                        <label for="cardSearchInput" class="brand-text text-gold mb-2">Search by card name</label>
+                        <input id="cardSearchInput" type="search" class="form-control form-control-lg bg-dark text-light border-secondary"
+                            placeholder="Start typing a card name..." autocomplete="off">
+                        <small id="cardSearchStatus" class="text-muted mt-2 d-block"></small>
+                        <div id="cardSearchResults" class="card-search-results mt-3" aria-live="polite"></div>
+                    </div>
+                </section>
+
                 <div class="text-center mt-4">
                     <button id="generateDeck" class="rune-btn primary" style="width: 100%; max-width: 300px;">
                         <i class="fas fa-dungeon me-2"></i> Generate Deck

--- a/styles.css
+++ b/styles.css
@@ -1693,3 +1693,36 @@ body {
         font-size: 0.7rem;
     }
 }
+
+/* Card search */
+.card-search-results {
+    display: grid;
+    gap: 12px;
+}
+
+.card-search-item {
+    display: grid;
+    grid-template-columns: 60px 1fr;
+    gap: 12px;
+    align-items: center;
+    padding: 10px;
+    background: rgba(0, 0, 0, 0.45);
+    border-radius: 10px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.card-search-thumb {
+    width: 60px;
+    height: auto;
+    border-radius: 6px;
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.45);
+}
+
+.card-search-name {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.card-search-type {
+    font-size: 0.85rem;
+}

--- a/ui-manager.js
+++ b/ui-manager.js
@@ -75,6 +75,11 @@ export function loadCardTypes() {
 
     state.availableCards = [...allCards];
 
+    const searchInput = document.getElementById('cardSearchInput');
+    if (searchInput) {
+        updateCardSearchResults(searchInput.value);
+    }
+
     allCards.forEach(card => {
         const typeInfo = parseCardTypes(card.type);
         typeInfo.allTypes.forEach(type => {
@@ -204,6 +209,42 @@ export function updateDifficultyDetails() {
 
     if (noviceInput) noviceInput.value = selectedDifficulty.novice || 0;
     if (veteranInput) veteranInput.value = selectedDifficulty.veteran || 0;
+}
+
+export function updateCardSearchResults(rawQuery) {
+    const resultsContainer = document.getElementById('cardSearchResults');
+    const status = document.getElementById('cardSearchStatus');
+    if (!resultsContainer || !status) return;
+
+    const query = (rawQuery || '').trim().toLowerCase();
+    resultsContainer.innerHTML = '';
+
+    if (!query) {
+        status.textContent = 'Type to search across all available cards.';
+        return;
+    }
+
+    const matches = state.availableCards.filter(card => card.card.toLowerCase().includes(query));
+    const sortedMatches = matches.sort((a, b) => a.card.localeCompare(b.card));
+    const maxResults = 50;
+    const displayMatches = sortedMatches.slice(0, maxResults);
+
+    status.textContent = matches.length === 0
+        ? 'No matching cards found.'
+        : `Showing ${displayMatches.length} of ${matches.length} matching cards.`;
+
+    displayMatches.forEach(card => {
+        const item = document.createElement('div');
+        item.classList.add('card-search-item');
+        item.innerHTML = `
+            <img src="cardimages/${card.contents}" alt="${card.card}" class="card-search-thumb">
+            <div>
+                <div class="card-search-name">${card.card}</div>
+                <div class="card-search-type text-muted">${card.type}</div>
+            </div>
+        `;
+        resultsContainer.appendChild(item);
+    });
 }
 
 /**


### PR DESCRIPTION
### Motivation
- Provide a way to search across all available cards by name from the Deck Builder UI. 
- Keep search results in sync with currently selected game sets while avoiding excessive updates via debouncing.

### Description
- Added a new `Card Search` section to `index.html` containing `#cardSearchInput`, `#cardSearchStatus`, and `#cardSearchResults` for searching and presenting matches. 
- Implemented `updateCardSearchResults(rawQuery)` in `ui-manager.js` to filter `state.availableCards`, sort matches, limit results to 50, and render thumbnail/name/type entries. 
- Trigger `updateCardSearchResults` from `loadCardTypes` so results refresh when selected games change and exported the function for external use. 
- Wired a debounced input handler `debouncedCardSearch` in `events.js` to call `updateCardSearchResults` on `input` events, and added UI styles in `styles.css` for `.card-search-results`, `.card-search-item`, and related classes.

### Testing
- Launched a local HTTP server and ran an automated Playwright script that navigated to `index.html` and captured a screenshot of the card search UI (`artifacts/card-search.png`), which completed successfully after a retry. 
- No unit tests were added or executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d074ed0cc8327838986077e63f8c9)