### PR TITLE
feat: consolidate rich event cards

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,36 @@
+# Project Context
+
+## Purpose
+
+Maladum Event Cards is the canonical static browser app for building Maladum event decks, running a live deck, searching the structured card catalog, and tracking campaigns. GitHub Pages serves the checked-in HTML, JavaScript, JSON, and assets; Node.js is local maintenance and validation tooling only.
+
+## Canonical Repository
+
+`BarryRodick/MaladumEventCards` is the sole development repository. Treat the former `BarryRodick/maladum-rich-event-cards` split repository as a reconciled donor pending archival; it must not receive new product work.
+
+The reconciliation decision and commit-by-commit disposition are recorded in [ADR 0001](docs/adr/0001-consolidate-rich-event-cards.md).
+
+## Current Product State
+
+- The structured catalog contains 142 human-verified cards across seven game files.
+- `maladumcards.json` remains the legacy compatibility source and extraction seed.
+- Main's `deck-rules.js`, `live-deck.js`, `live-deck-session.js`, `live-deck-view.js`, `app-snapshot.js`, and `campaign-tracker.js` are the authoritative runtime architecture.
+- Browser state is local to the user's `localStorage`; the app has no application server or account system.
+
+## Validation
+
+Run these checks before merging card or runtime changes:
+
+```bash
+npm ci
+npm run build
+npm test
+npm run validate:cards
+git diff --check
+```
+
+`npm run build` synchronizes the version and offline asset manifest. Review generated changes before committing.
+
+## Work Tracking
+
+Use this repository's GitHub Issues and the canonical triage labels documented in `docs/agents/`.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Maladum Event Cards is a static browser app for managing event decks and campaig
 
 [https://barryrodick.github.io/MaladumEventCards/](https://barryrodick.github.io/MaladumEventCards/)
 
+This is the canonical project. The former standalone `maladum-rich-event-cards` experiment was reconciled into this repository for version 2.16.1; new code, issues, and card corrections belong here.
+
 ## Using the App
 
 1. Open the GitHub Pages link.
@@ -126,7 +128,7 @@ The OpenRouter enrichment step only promotes clean automated results to `auto`; 
 
 ## Reviewing And Editing Cards
 
-Manual review is expected during migration.
+The tracked catalog currently contains 142 human-verified rich cards. Use this review workflow when adding cards, changing extracted text, or rerunning the extractor.
 
 - Open [reports/card-review/index.html](reports/card-review/index.html) after running `npm run review:cards`.
 - Compare the source image on the left with the structured render and raw extraction metadata on the right.
@@ -161,6 +163,8 @@ For a new or updated card:
 - The service worker now caches structured card JSON and local SVG icon assets as part of the app shell.
 
 ## Current Extractor Limitations
+
+These limitations apply to newly extracted or force-regenerated records; the tracked 142-card catalog has been reviewed and verified.
 
 - Footer icon matching is intentionally conservative and currently defaults many detected footer glyphs to `unknown-icon`.
 - OCR is used as confirmation and review input, not as an unquestioned source of truth.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ A rich card record looks like this:
 
 ## Commands
 
-The deployed app is static and requires no installation. Contributors need Node.js and can install the extraction and review tooling with:
+The deployed app is static and requires no installation. Contributors need Node.js 20.9 or later and can install the extraction and review tooling with:
 
 ```bash
 npm install

--- a/assets/icons/cleave.svg
+++ b/assets/icons/cleave.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M6 18.5L17.9 6.6" stroke="#1d1a17" stroke-width="5" stroke-linecap="round"/>
+  <path d="M18 18.5L6.1 6.6" stroke="#1d1a17" stroke-width="5" stroke-linecap="round"/>
+  <path d="M6 18.5L17.9 6.6" stroke="#ece7df" stroke-width="2.8" stroke-linecap="round"/>
+  <path d="M18 18.5L6.1 6.6" stroke="#ece7df" stroke-width="2.8" stroke-linecap="round"/>
+  <path d="M15 3.8C18.3 3.6 20.8 5.1 21.4 7.7L17.7 9.2L14.8 6.3L15 3.8Z" fill="#ece7df" stroke="#1d1a17" stroke-width="1.4" stroke-linejoin="round"/>
+  <path d="M9 3.8C5.7 3.6 3.2 5.1 2.6 7.7L6.3 9.2L9.2 6.3L9 3.8Z" fill="#ece7df" stroke="#1d1a17" stroke-width="1.4" stroke-linejoin="round"/>
+</svg>

--- a/assets/icons/hit-and-run.svg
+++ b/assets/icons/hit-and-run.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M3.5 15.4L8.3 5.2L11.5 9.1L18.8 4.6L20.5 8.3L13.4 12.8L17.9 18.1L14.2 20.4L9.5 15L6.8 20.1L3.5 15.4Z" fill="#f4f0e8" stroke="#1b1716" stroke-width="1.5" stroke-linejoin="round"/>
+  <path d="M4.1 11.4L2.7 7.7L7 8.6" stroke="#c4312b" stroke-width="2.7" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M2.8 16.8L7.5 14.6" stroke="#c4312b" stroke-width="2.7" stroke-linecap="round"/>
+</svg>

--- a/assets/icons/potion.svg
+++ b/assets/icons/potion.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M9.2 2.5H14.8V6.5L18.3 12.3C20.5 15.9 18.1 21.5 12 21.5C5.9 21.5 3.5 15.9 5.7 12.3L9.2 6.5V2.5Z" fill="#9b54b5" stroke="#f3e8ff" stroke-width="3" stroke-linejoin="round"/>
+  <path d="M9.2 2.5H14.8V6.5L18.3 12.3C20.5 15.9 18.1 21.5 12 21.5C5.9 21.5 3.5 15.9 5.7 12.3L9.2 6.5V2.5Z" fill="#9b54b5" stroke="#1d1a17" stroke-width="1.2" stroke-linejoin="round"/>
+  <path d="M8.3 12.6C9.7 13.2 14.2 13.2 15.7 12.6" stroke="#d6a5e6" stroke-width="1.2" stroke-linecap="round"/>
+</svg>

--- a/assets/icons/quickstrike.svg
+++ b/assets/icons/quickstrike.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M3 6.5L10.8 12L3 17.5V13.7L8.2 12L3 10.3V6.5Z" fill="#f4f0e8" stroke="#1d1a17" stroke-width="1.6" stroke-linejoin="round"/>
+  <path d="M10.4 5.6L21.5 12L10.4 18.4V14.1L16.7 12L10.4 9.9V5.6Z" fill="#f4f0e8" stroke="#1d1a17" stroke-width="1.6" stroke-linejoin="round"/>
+</svg>

--- a/assets/icons/sundering.svg
+++ b/assets/icons/sundering.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M12 2.5L20.2 5.8V11.2C20.2 16.3 16.7 20.4 12 22C7.3 20.4 3.8 16.3 3.8 11.2V5.8L12 2.5Z" fill="#f0323b" stroke="#1b1716" stroke-width="1.7" stroke-linejoin="round"/>
+  <path d="M12.1 3.3L12.8 8.3L9.3 10.9L12.5 13.1L10.9 20.5" stroke="#1b1716" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M13 8.3L17.1 7.3M12.5 13.1L17.2 14.8" stroke="#1b1716" stroke-width="1.25" stroke-linecap="round"/>
+</svg>

--- a/assets/icons/vicious.svg
+++ b/assets/icons/vicious.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M7.2 4.2L3.8 16.7" stroke="#1f1a17" stroke-width="4.2" stroke-linecap="round"/>
+  <path d="M13.1 3.2L8.7 18.8" stroke="#1f1a17" stroke-width="4.2" stroke-linecap="round"/>
+  <path d="M19 5.5L14.2 20.2" stroke="#1f1a17" stroke-width="4.2" stroke-linecap="round"/>
+  <path d="M7.2 4.2L3.8 16.7" stroke="#b6281f" stroke-width="2.6" stroke-linecap="round"/>
+  <path d="M13.1 3.2L8.7 18.8" stroke="#d33a2f" stroke-width="2.6" stroke-linecap="round"/>
+  <path d="M19 5.5L14.2 20.2" stroke="#c93229" stroke-width="2.6" stroke-linecap="round"/>
+</svg>

--- a/assets/icons/wounded.svg
+++ b/assets/icons/wounded.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M9.3 2.7C6.1 7.3 4.6 10.8 4.6 14C4.6 17.2 6.6 19.5 9.4 19.5C12.2 19.5 14.1 17.2 14.1 14C14.1 10.8 12.5 7.3 9.3 2.7Z" fill="#cf2f35" stroke="#1b1716" stroke-width="1.4" stroke-linejoin="round"/>
+  <path d="M16.9 7.8C14.9 10.8 14 13 14 15C14 17 15.3 18.5 17 18.5C18.8 18.5 20 17 20 15C20 13 19 10.8 16.9 7.8Z" fill="#dd3a3f" stroke="#1b1716" stroke-width="1.25" stroke-linejoin="round"/>
+  <path d="M7.8 7.9C6.8 10.1 6.5 11.5 6.5 13.2" stroke="#f39aa0" stroke-width="1.1" stroke-linecap="round" opacity="0.8"/>
+</svg>

--- a/card-data.mjs
+++ b/card-data.mjs
@@ -94,16 +94,22 @@ export function buildCardSearchText(card) {
         .map(item => item.type === 'label' ? item.text : item.name)
         .join(' ');
 
-    return [
+    return normalizeSearchText([
         card.card,
         card.type,
         card.game,
         ...toArray(card.tags),
         sectionText,
         footerText
-    ]
-        .join(' ')
+    ].join(' '));
+}
+
+function normalizeSearchText(text = '') {
+    return String(text)
+        .trim()
         .toLowerCase()
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
         .replace(/\s+/g, ' ')
         .trim();
 }
@@ -220,7 +226,7 @@ export function normalizeCachedCardCatalog(cachedCatalog = {}) {
 }
 
 export function searchCards(cards = [], rawQuery = '') {
-    const query = String(rawQuery || '').trim().toLowerCase();
+    const query = normalizeSearchText(rawQuery);
     if (!query) {
         return [];
     }

--- a/card-renderer.mjs
+++ b/card-renderer.mjs
@@ -28,23 +28,6 @@ function appendSectionParagraphs(doc, sectionBody, section, options) {
     });
 }
 
-function createMetaRow(doc, card) {
-    const meta = doc.createElement('div');
-    meta.className = 'card-surface__meta';
-
-    const type = doc.createElement('span');
-    type.className = 'card-meta-pill';
-    type.textContent = card.type;
-    meta.appendChild(type);
-
-    const game = doc.createElement('span');
-    game.className = 'card-meta-pill card-meta-pill--muted';
-    game.textContent = card.game;
-    meta.appendChild(game);
-
-    return meta;
-}
-
 function createFooter(doc, card, options, { compact = false } = {}) {
     if (!card.footer || (!Array.isArray(card.footer.left) && !Array.isArray(card.footer.right))) {
         return null;
@@ -101,8 +84,6 @@ function renderRichCard(doc, card, options = {}, size = 'full') {
     article.appendChild(title);
 
     if (size !== 'compact') {
-        article.appendChild(createMetaRow(doc, card));
-
         const sections = doc.createElement('div');
         sections.className = 'card-surface__sections';
 

--- a/data/cards/base-game.json
+++ b/data/cards/base-game.json
@@ -14,14 +14,12 @@
         {
           "kind": "mode",
           "label": "DISQUIET-DISTRESS",
-          "text": "Your enemies are spurred on by unseen forces. All Adversaries in play immediately take one action following the normal rules.",
-          "threshold": 1
+          "text": "Your enemies are spurred on by unseen forces. All Adversaries in play immediately take one action following the normal rules."
         },
         {
           "kind": "mode",
           "label": "DISMAY-DESPERATION",
-          "text": "The three Adversaries closest to an Adventurer are Blessed. Then, all Adversaries in play immediately take one action following the normal rules.",
-          "threshold": 2
+          "text": "The three Adversaries closest to an Adventurer are Blessed. Then, all Adversaries in play immediately take one action following the normal rules."
         },
         {
           "kind": "mode",
@@ -33,7 +31,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -43,12 +41,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "renewed vigour environment base game disquiet-distress your enemies are spurred on by unseen forces. all adversaries in play immediately take one action following the normal rules. dismay-desperation the three adversaries closest to an adventurer are blessed. then, all adversaries in play immediately take one action following the normal rules. disaster-doom flip the adversary board to the reverse side, if not already flipped. then, all adversaries in play immediately take one action following the normal rules. unknown-icon unknown-icon"
+      "searchText": "renewed vigour environment base game disquiet-distress your enemies are spurred on by unseen forces. all adversaries in play immediately take one action following the normal rules. dismay-desperation the three adversaries closest to an adventurer are blessed. then, all adversaries in play immediately take one action following the normal rules. disaster-doom flip the adversary board to the reverse side, if not already flipped. then, all adversaries in play immediately take one action following the normal rules. environment"
     },
     {
       "id": 2,
@@ -70,7 +68,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "grave"
+            "name": "revenant"
           }
         ],
         "right": []
@@ -82,12 +80,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "life drain revenant base game disquiet-doom the adventurer with the most health suffers 2 damage (up to a maximum of their remaining health). they may spend magic pegs to reduce this damage. if the malagaunt is in play, it restores health equal to the damage inflicted (this may exceed its starting health). otherwise, that many lamentors arrive, if available, at the nearest empty grave points to the adventurer. unknown-icon unknown-icon"
+      "searchText": "life drain revenant base game revenant disquiet-doom the adventurer with the most health suffers 2 damage (up to a maximum of their remaining health). they may spend magic pegs to reduce this damage. if the malagaunt is in play, it restores health equal to the damage inflicted (this may exceed its starting health). otherwise, that many lamentors arrive, if available, at the nearest empty grave points to the adventurer. revenant"
     },
     {
       "id": 3,
@@ -102,15 +100,14 @@
         {
           "kind": "mode",
           "label": "DISQUIET-DOOM",
-          "text": "The Malagaunt channels its magic through one of its minions. The closest unengaged Adversary to an enemy targets that enemy with a two-dice ranged attack with [fire].\n\nThen, all unengaged Adversaries make a Move action.",
-          "threshold": 2
+          "text": "The Malagaunt channels its magic through one of its minions. The closest unengaged Adversary to an enemy targets that enemy with a two-dice ranged attack with [fire].\n\nThen, all unengaged Adversaries make a Move action."
         }
       ],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "revenant"
           }
         ],
         "right": []
@@ -122,12 +119,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "balefire revenant base game disquiet-doom the malagaunt channels its magic through one of its minions. the closest unengaged adversary to an enemy targets that enemy with a two-dice ranged attack with fire . then, all unengaged adversaries make a move action. unknown-icon unknown-icon"
+      "searchText": "balefire revenant base game revenant disquiet-doom the malagaunt channels its magic through one of its minions. the closest unengaged adversary to an enemy targets that enemy with a two-dice ranged attack with fire . then, all unengaged adversaries make a move action. revenant"
     },
     {
       "id": 4,
@@ -149,7 +146,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "novice"
           }
         ],
         "right": []
@@ -159,12 +156,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "respite novice base game disquiet-doom there is an unexpected lull in the seemingly endless onslaught. reduce dread by 2. no adversaries will arrive this round. adventurers already in play will activate as normal. unknown-icon unknown-icon"
+      "searchText": "respite novice base game disquiet-doom there is an unexpected lull in the seemingly endless onslaught. reduce dread by 2. no adversaries will arrive this round. adversaries already in play will activate as normal. novice"
     },
     {
       "id": 5,
@@ -186,7 +183,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -196,12 +193,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "snap environment base game disquiet-doom select an adventurer at random. a random item that they are carrying is broken. turn the item face down in their inventory. unknown-icon unknown-icon"
+      "searchText": "snap environment base game disquiet-doom select an adventurer at random. a random item that they are carrying is broken. turn the item face down in their inventory. environment"
     },
     {
       "id": 6,
@@ -238,7 +235,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -248,12 +245,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "malacytic fluctuations environment base game disquiet each adventurer feels buoyed as natural energy flows through them. all characters gain a magic peg â€“ this may exceed their starting value. distress the adventurers feel suddenly drained by an unnatural force. all characters discard a magic peg. if they cannot they become fatigued. dismay-desperation all characters gain two magic pegs â€“ this may exceed their starting value. disaster-doom all characters discard two magic pegs. if they cannot they become fatigued for each. unknown-icon unknown-icon"
+      "searchText": "malacytic fluctuations environment base game disquiet each adventurer feels buoyed as natural energy flows through them. all characters gain a magic peg – this may exceed their starting value. distress the adventurers feel suddenly drained by an unnatural force. all characters discard a magic peg. if they cannot they become fatigued. dismay-desperation all characters gain two magic pegs – this may exceed their starting value. disaster-doom all characters discard two magic pegs. if they cannot they become fatigued for each. environment"
     },
     {
       "id": 7,
@@ -280,7 +277,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -290,12 +287,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "trap! arrow dungeon base game todo todo - image too small to read unknown-icon unknown-icon"
+      "searchText": "trap! arrow dungeon base game disquiet-dismay an adventurer trips a wire and an arrow shoots from the wall! a random adventurer suffers a ranged attack with one die and sharp sharp . shuffle this card back into the deck. desperation-doom an adventurer trips a wire and a hail of arrows fills the room! select a random adventurer. that character and all other characters in the same room suffer a ranged attack with one die and sharp sharp (roll separately for each). dungeon"
     },
     {
       "id": 8,
@@ -310,15 +307,14 @@
         {
           "kind": "mode",
           "label": "DISQUIET-DOOM",
-          "text": "The Malagaunt channels its magic through its minions. All engaged Adversaries make a two-dice melee attack with [fire].\n\nThen, all unengaged Adversaries make a Move action.",
-          "threshold": 2
+          "text": "The Malagaunt channels its magic through its minions. All engaged Adversaries make a two-dice melee attack with [fire].\n\nThen, all unengaged Adversaries make a Move action."
         }
       ],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "grave"
+            "name": "revenant"
           }
         ],
         "right": []
@@ -328,12 +324,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "fiery touch revenant base game disquiet-doom the malagaunt channels its magic through its minions. all engaged adversaries make a two-dice melee attack with fire . then, all unengaged adversaries make a move action. unknown-icon unknown-icon"
+      "searchText": "fiery touch revenant base game disquiet-doom the malagaunt channels its magic through its minions. all engaged adversaries make a two-dice melee attack with fire . then, all unengaged adversaries make a move action. revenant"
     },
     {
       "id": 9,
@@ -355,7 +351,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "novice"
           }
         ],
         "right": []
@@ -365,12 +361,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "feeling lucky novice base game disquiet-doom reduce dread by 1. all adventurers in play become blessed. unknown-icon unknown-icon"
+      "searchText": "feeling lucky novice base game disquiet-doom reduce dread by 1. all adventurers in play become blessed. novice"
     },
     {
       "id": 10,
@@ -402,7 +398,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -412,12 +408,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "alarm! environment base game disquiet your presence has sounded an alarm. increase the dread by 1. distress-dismay place this card next to the dread tracker and place three black pegs on top of it. add one of these pegs to the tracker in each assessment phase. when all pegs have been used, discard this card. desperation-doom increase the dread by 1. then roll the magic die for each adventurer. on a 1, that adventurer becomes terrified. then discard this card and draw another. unknown-icon unknown-icon"
+      "searchText": "alarm! environment base game disquiet your presence has sounded an alarm. increase the dread by 1. distress-dismay place this card next to the dread tracker and place three black pegs on top of it. add one of these pegs to the tracker in each assessment phase. when all pegs have been used, discard this card. desperation-doom increase the dread by 1. then roll the magic die for each adventurer. on a 1, that adventurer becomes terrified. then discard this card and draw another. environment"
     },
     {
       "id": 11,
@@ -432,8 +428,7 @@
         {
           "kind": "mode",
           "label": "DISQUIET-DISMAY",
-          "text": "All non-Adversaries within short range of a Revenant become Terrified. They may spend a Magic peg to ignore this effect.",
-          "threshold": 1
+          "text": "All non-Adversaries within short range of a Revenant become Terrified. They may spend a Magic peg to ignore this effect."
         },
         {
           "kind": "mode",
@@ -445,7 +440,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "revenant"
           }
         ],
         "right": []
@@ -457,12 +452,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "chilling aura revenant base game disquiet-dismay all non-adversaries within short range of a revenant become terrified. they may spend a magic peg to ignore this effect. desperation-doom all non-adversaries within short range of a revenant become terrified and fatigued. they may spend one magic peg to ignore each effect. unknown-icon unknown-icon"
+      "searchText": "chilling aura revenant base game revenant disquiet-dismay all non-adversaries within short range of a revenant become terrified. they may spend a magic peg to ignore this effect. desperation-doom all non-adversaries within short range of a revenant become terrified and fatigued. they may spend one magic peg to ignore each effect. revenant"
     },
     {
       "id": 12,
@@ -489,7 +484,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "grave"
+            "name": "revenant"
           }
         ],
         "right": []
@@ -501,12 +496,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "reanimation revenant base game disquiet-distress place a lamentor at the nearest empty grave point to an adventurer. it activates immediately, and will activate again in the adversary phase. dismay-doom target a random defeated adventurer, if any. the adventurer stands up, and then takes 3 actions as if they were an adversary. the defeated adventurer may spend magic pegs to reduce this number of actions. after any actions have been taken, the character is laid prone and marked as defeated again. if there are no defeated adventurers, place a lamentor at the nearest empty grave point to an adventurer and activate it. unknown-icon unknown-icon"
+      "searchText": "reanimation revenant base game revenant disquiet-distress place a lamentor at the nearest empty grave point to an adventurer. it activates immediately, and will activate again in the adversary phase. dismay-doom target a random defeated adventurer, if any. the adventurer stands up, and then takes 3 actions as if they were an adversary. the defeated adventurer may spend magic pegs to reduce this number of actions. after any actions have been taken, the character is laid prone and marked as defeated again. if there are no defeated adventurers, place a lamentor at the nearest empty grave point to an adventurer and activate it. revenant"
     },
     {
       "id": 13,
@@ -521,27 +516,24 @@
         {
           "kind": "mode",
           "label": "DISQUIET",
-          "text": "Choose the Adventurer with the fewest Health pegs. All enemies within medium range and LoS not engaged with another Adventurer take one action with the chosen Adventurer as the target.",
-          "threshold": 1
+          "text": "Choose the Adventurer with the fewest Health pegs. All enemies within medium range and LoS not engaged with another Adventurer take one action with the chosen Adventurer as the target."
         },
         {
           "kind": "mode",
           "label": "DISTRESS-DISMAY",
-          "text": "Choose the Adventurer with the most Magic pegs. All enemies within medium range and LoS not engaged with another Adventurer take one action with the chosen Adventurer as the target.",
-          "threshold": 2
+          "text": "Choose the Adventurer with the most Magic pegs. All enemies within medium range and LoS not engaged with another Adventurer take one action with the chosen Adventurer as the target."
         },
         {
           "kind": "mode",
           "label": "DESPERATION-DOOM",
-          "text": "Choose the Adventurer with the most Health pegs. All enemies within medium range and LoS not engaged with another Adventurer take one action with the chosen Adventurer as the target.",
-          "threshold": 3
+          "text": "Choose the Adventurer with the most Health pegs. All enemies within medium range and LoS not engaged with another Adventurer take one action with the chosen Adventurer as the target."
         }
       ],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "revenant"
           }
         ],
         "right": []
@@ -551,12 +543,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "get that one! revenant base game disquiet choose the adventurer with the fewest health pegs. all enemies within medium range and los not engaged with another adventurer take one action with the chosen adventurer as the target. distress-dismay choose the adventurer with the most magic pegs. all enemies within medium range and los not engaged with another adventurer take one action with the chosen adventurer as the target. desperation-doom choose the adventurer with the most health pegs. all enemies within medium range and los not engaged with another adventurer take one action with the chosen adventurer as the target. unknown-icon unknown-icon"
+      "searchText": "get that one! revenant base game disquiet choose the adventurer with the fewest health pegs. all enemies within medium range and los not engaged with another adventurer take one action with the chosen adventurer as the target. distress-dismay choose the adventurer with the most magic pegs. all enemies within medium range and los not engaged with another adventurer take one action with the chosen adventurer as the target. desperation-doom choose the adventurer with the most health pegs. all enemies within medium range and los not engaged with another adventurer take one action with the chosen adventurer as the target. revenant"
     },
     {
       "id": 14,
@@ -583,7 +575,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "grave"
+            "name": "revenant"
           }
         ],
         "right": []
@@ -595,12 +587,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "deathly fusion revenant base game disquiet-distress determine the lamentor closest to a terrain piece with armour 1 (e.g. barricade, crate). replace the lamentor with a myria and bless it; then remove the terrain piece from play, breaking and scattering any items inside. if no lamentors are in play or no myria are available, increase the dread by 1 and shuffle this card back into the deck. dismay-doom for each hellfont not currently in play, determine the lamentor closest to a crucible of resurrection. replace the lamentors with hellfonts and bless them. if no crucibles are in play or no hellfonts are available, resolve as disquiet-distress. unknown-icon unknown-icon"
+      "searchText": "deathly fusion revenant base game revenant disquiet-distress determine the lamentor closest to a terrain piece with armour 1 (e.g. barricade, crate). replace the lamentor with a myria and bless it; then remove the terrain piece from play, breaking and scattering any items inside. if no lamentors are in play or no myria are available, increase the dread by 1 and shuffle this card back into the deck. dismay-doom for each hellfont not currently in play, determine the lamentor closest to a crucible of resurrection. replace the lamentors with hellfonts and bless them. if no crucibles are in play or no hellfonts are available, resolve as disquiet-distress. revenant"
     },
     {
       "id": 15,
@@ -622,7 +614,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "grave"
+            "name": "revenant"
           }
         ],
         "right": []
@@ -634,12 +626,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "they're below us! revenant base game disquiet-doom all non-commander adversaries arriving this round arrive from grave points, not entry points. in addition, characters do not block grave points this round â€“ adversaries that would arrive there are placed in contact with the character on top. if a rot troll would arrive, place a pit terrain piece on top of the selected grave point, and place the rot troll in contact with it, pushing other characters aside if necessary. any character on the pit falls in. any non-adversary character in contact with the pit must spend a skill peg (reaction) or fall in. the pit remains in play, following the normal rules. unknown-icon unknown-icon"
+      "searchText": "they're below us! revenant base game revenant disquiet-doom all non-commander adversaries arriving this round arrive from grave points, not entry points. in addition, characters do not block grave points this round – adversaries that would arrive there are placed in contact with the character on top. if a rot troll would arrive, place a pit terrain piece on top of the selected grave point, and place the rot troll in contact with it, pushing other characters aside if necessary. any character on the pit falls in. any non-adversary character in contact with the pit must spend a skill peg (reaction) or fall in. the pit remains in play, following the normal rules. revenant"
     },
     {
       "id": 16,
@@ -654,19 +646,14 @@
         {
           "kind": "mode",
           "label": "DISQUIET-DOOM",
-          "text": "The Adversary (not including Commanders) furthest from an Adventurer is immediately defeated. Give the Malagaunt a number of Blessed counters equal to that Adversary's rank (even if the Malagaunt hasn't entered play yet).",
-          "threshold": 1
+          "text": "The Adversary (not including Commanders) furthest from an Adventurer is immediately defeated. Give the Malagaunt a number of Blessed counters equal to that Adversary's rank (even if the Malagaunt hasn't entered play yet)."
         }
       ],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "creature"
-          },
-          {
-            "type": "icon",
-            "name": "arrow-up"
+            "name": "malagaunt"
           }
         ],
         "right": []
@@ -676,12 +663,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "unnatural lifeforce malagaunt base game disquiet-doom the adversary (not including commanders) furthest from an adventurer is immediately defeated. give the malagaunt a number of blessed counters equal to that adversary's rank (even if the malagaunt hasn't entered play yet). unknown-icon unknown-icon"
+      "searchText": "unnatural lifeforce malagaunt base game disquiet-doom the adversary (not including commanders) furthest from an adventurer is immediately defeated. give the malagaunt a number of blessed counters equal to that adversary's rank (even if the malagaunt hasn't entered play yet). malagaunt"
     },
     {
       "id": 17,
@@ -708,11 +695,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "otherworldly"
-          },
-          {
-            "type": "icon",
-            "name": "arrow-up"
+            "name": "malagaunt"
           }
         ],
         "right": []
@@ -724,12 +707,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "death draws in malagaunt base game disquiet-distress increase the dread by 2 and shuffle this card back into the deck. dismay-doom if the deathly avatar is in play, replace it with the malagaunt. flip the character board and adjust its pegs to the starting statistics of the malagaunt. then bless the malagaunt. otherwise, the malagaunt is placed at a random entry point. if the malagaunt is already in play, it becomes blessed. unknown-icon unknown-icon"
+      "searchText": "death draws in malagaunt base game malagaunt disquiet-distress increase the dread by 2 and shuffle this card back into the deck. dismay-doom if the deathly avatar is in play, replace it with the malagaunt. flip the character board and adjust its pegs to the starting statistics of the malagaunt. then bless the malagaunt. otherwise, the malagaunt is placed at a random entry point. if the malagaunt is already in play, it becomes blessed. malagaunt"
     },
     {
       "id": 18,
@@ -756,7 +739,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -766,12 +749,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "gleaming trinket environment base game disquiet-doom an adventurer spots something shining in the distance, but there's something blocking the view... determine the square on the board furthest from any adventurers that at least one adventurer has los to. place an unused objective token (or reminder counter if no objectives are available) in that square. then place the highest-ranking adversary available in the current dread band in a square adjacent to the token. set this card aside as a reminder. if the objective token is retrieved, roll the magic die and replace it with the following: 1-2: a random item from the token pouch 3-4: a random uncommon item 5-6: a random rare item token size does not matter. then discard this card. unknown-icon unknown-icon"
+      "searchText": "gleaming trinket environment base game disquiet-doom an adventurer spots something shining in the distance, but there's something blocking the view... determine the square on the board furthest from any adventurers that at least one adventurer has los to. place an unused objective token (or reminder counter if no objectives are available) in that square. then place the highest-ranking adversary available in the current dread band in a square adjacent to the token. set this card aside as a reminder. if the objective token is retrieved, roll the magic die and replace it with the following: 1-2: a random item from the token pouch 3-4: a random uncommon item 5-6: a random rare item token size does not matter. then discard this card. environment"
     },
     {
       "id": 19,
@@ -803,7 +786,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -813,12 +796,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "tremors environment base game disquiet-distress the ground shakes. set this card aside. all attacks roll one fewer die until the end of the round, and all move distances are decreased by 1 square. discard this card at the end of the round. dismay there is an unexpected seismic shift. all characters not in contact with a wall are knocked prone. then, as disquiet-distress. desperation-doom a rotten floor gives way. the first player chooses a point on the board and scatters twice, ignoring terrain. place a pit terrain piece as close as possible to that location (avoiding terrain but ignoring characters). any character on the pit falls in. any character adjacent to the pit must spend a skill peg (reaction) or fall in. the pit remains in play, following the normal rules. then, as disquiet-distress. unknown-icon unknown-icon"
+      "searchText": "tremors environment base game disquiet-distress the ground shakes. set this card aside. all attacks roll one fewer die until the end of the round, and all move distances are decreased by 1 square. discard this card at the end of the round. dismay there is an unexpected seismic shift. all characters not in contact with a wall are knocked prone. then, as disquiet-distress. desperation-doom a rotten floor gives way. the first player chooses a point on the board and scatters twice, ignoring terrain. place a pit terrain piece as close as possible to that location (avoiding terrain but ignoring characters). any character on the pit falls in. any character adjacent to the pit must spend a skill peg (reaction) or fall in. the pit remains in play, following the normal rules. then, as disquiet-distress. environment"
     },
     {
       "id": 20,
@@ -850,7 +833,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -860,12 +843,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "spooked environment base game disquiet you are distracted by distant noises. increase the dread by 1 and shuffle this card back into the deck. distress-dismay there are strange shapes lurking in the shadows. a random adventurer becomes terrified. desperation-doom hysteria is spreading. a random adventurer becomes terrified and fatigued, and all adventurers within short range of the target become terrified. unknown-icon unknown-icon"
+      "searchText": "spooked environment base game disquiet you are distracted by distant noises. increase the dread by 1 and shuffle this card back into the deck. distress-dismay there are strange shapes lurking in the shadows. a random adventurer becomes terrified. desperation-doom hysteria is spreading. a random adventurer becomes terrified and fatigued, and all adventurers within short range of the target become terrified. environment"
     },
     {
       "id": 21,
@@ -892,7 +875,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -902,12 +885,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "as one door closes... environment base game disquiet-dismay what was once a safe staging point is no longer safe â€“ your escape route has been blocked! however, you've spotted an alternative way out, if you can get there. the first player rolls the magic die and swaps their staging point with the matching entry point. desperation-doom hordes of enemies appear at what you thought was a safe escape route. at this point you have no choice but to fight your way out. the first player rolls the magic die twice, re-rolling duplicates. the entry points matching the numbers rolled are moved adjacent to the player's staging point. unknown-icon unknown-icon"
+      "searchText": "as one door closes... environment base game disquiet-dismay what was once a safe staging point is no longer safe – your escape route has been blocked! however, you've spotted an alternative way out, if you can get there. the first player rolls the magic die and swaps their staging point with the matching entry point. desperation-doom hordes of enemies appear at what you thought was a safe escape route. at this point you have no choice but to fight your way out. the first player rolls the magic die twice, re-rolling duplicates. the entry points matching the numbers rolled are moved adjacent to the player's staging point. environment"
     },
     {
       "id": 22,
@@ -929,7 +912,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -939,12 +922,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "trap! snare environment base game disquiet-doom an adventurer stumbles into a snare laid for a wild animal! a random adventurer suffers an attack with three dice, sharp sharp and entangling entangling . unknown-icon unknown-icon"
+      "searchText": "trap! snare environment base game disquiet-doom an adventurer stumbles into a snare laid for a wild animal! a random adventurer suffers an attack with three dice, sharp sharp and entangling entangling . environment"
     },
     {
       "id": 23,
@@ -966,7 +949,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -976,12 +959,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "they're everywhere environment base game disquiet-doom you've noticed them here and there; some kind of vermin clustered on columns and ceilings, probably attracted by the residual energy of your magic. they were no bother at first, but now they seem to consider you a threat and they attack! roll a combat die for each non-adversary character in play. on a paw they become poisoned. otherwise, they suffer fatigued counters equal to the number of hits rolled as they fight off the creatures. stunned characters do not roll â€“ they are automatically poisoned. unknown-icon unknown-icon"
+      "searchText": "they're everywhere environment base game disquiet-doom you've noticed them here and there; some kind of vermin clustered on columns and ceilings, probably attracted by the residual energy of your magic. they were no bother at first, but now they seem to consider you a threat and they attack! roll a combat die for each non-adversary character in play. on a skull they become poisoned. otherwise, they suffer fatigued counters equal to the number of hits rolled as they fight off the creatures. stunned characters do not roll – they are automatically poisoned. environment"
     },
     {
       "id": 24,
@@ -1013,12 +996,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "lost traveller denizen base game todo todo - image too small to read unknown-icon unknown-icon"
+      "searchText": "lost traveller denizen base game disquiet-doom select a random denizen. it gains one random item from the token pouch. place the miniature at a random entry point. the character scatters once per action. it will not engage enemies - it will stop one square away if there is no route around. if it starts its turn engaged, it will make a melee attack if possible, or a knock back if not. if still engaged it will move directly away if possible, or attack/knock back again if not. it resumes its normal rules for any remaining actions. if this character is persuaded to leave play via a staging point, the rescuing player gains one renown. denizen"
     },
     {
       "id": 25,
@@ -1057,12 +1040,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "lost traveller denizen base game todo todo - image too small to read unknown-icon unknown-icon"
+      "searchText": "lost traveller denizen base game denizen disquiet-doom select a random denizen. it gains one random item from the token pouch. place the miniature at a random entry point. the character scatters once per action. it will not engage enemies - it will stop one square away if there is no route around. if it starts its turn engaged, it will make a melee attack if possible, or a knock back if not. if still engaged it will move directly away if possible, or attack/knock back again if not. it resumes its normal rules for any remaining actions. if this character is persuaded to leave play via a staging point, the rescuing player gains one renown. denizen"
     },
     {
       "id": 26,
@@ -1096,10 +1079,10 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.95,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
       "searchText": "opportunist denizen base game denizen disquiet-doom select a random denizen. place the miniature at a random entry point. if the character’s inventory has space, it will move towards the nearest, least threatened searchable terrain piece, loose item or defeated adventurer and search, taking random items until its inventory is full. when its inventory is full, it will move towards the nearest entry point and then interact to discard the items into its hidden cache. it will not engage enemies - it will stop one square away if there is no route around. if it starts its turn engaged, it will make a melee attack with the plunderer plunderer rule if possible, or a knock back if not. if still engaged it will move directly away if possible, or attack/knock back again if not. it resumes its normal rules for any remaining actions. denizen"
     },
@@ -1135,12 +1118,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "opportunist denizen base game todo todo - image too small to read unknown-icon unknown-icon"
+      "searchText": "opportunist denizen base game denizen disquiet-doom select a random denizen. place the miniature at a random entry point. if the character’s inventory has space, it will move towards the nearest, least threatened searchable terrain piece, loose item or defeated adventurer and search, taking random items until its inventory is full. when its inventory is full, it will move towards the nearest entry point and then interact to discard the items into its hidden cache. it will not engage enemies - it will stop one square away if there is no route around. if it starts its turn engaged, it will make a melee attack with the plunderer plunderer rule if possible, or a knock back if not. if still engaged it will move directly away if possible, or attack/knock back again if not. it resumes its normal rules for any remaining actions. denizen"
     },
     {
       "id": 28,
@@ -1179,12 +1162,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "on the hunt denizen base game todo todo - image too small to read unknown-icon unknown-icon"
+      "searchText": "on the hunt denizen base game denizen disquiet-doom select a random denizen. it gains one additional health peg, one random uncommon ranged weapon, one random uncommon melee weapon and one random item from the token pouch. place the miniature at a random entry point. this character follows normal npc activation rules. however, if unengaged it will target the largest, highest-ranking enemy in play. it will also consider any character larger than itself and/or with the worthy opponent worthy-opponent rule to be an enemy, regardless of character type. denizen"
     },
     {
       "id": 29,
@@ -1221,12 +1204,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "out for blood denizen base game todo todo - image too small to read unknown-icon unknown-icon"
+      "searchText": "out for blood denizen base game disquiet-doom select a random denizen. it gains two additional health pegs, one additional magic peg, one random uncommon weapon and one random item from the token pouch. place the miniature at a random entry point. this character follows normal npc activation rules, considering all other characters to be enemies. denizen"
     },
     {
       "id": 30,
@@ -1245,11 +1228,11 @@
         },
         {
           "kind": "box",
-          "label": "NPC Activation Rules",
+          "label": "",
           "text": "These characters follow normal NPC activation rules considering all other characters to be enemies.\n\nHowever, if unengaged they will target the closest enemy with Magic pegs, if possible."
         },
         {
-          "kind": "body",
+          "kind": "mode",
           "label": "DESPERATION-DOOM",
           "text": "As above, but flip the Cankers’ character board to the Elite side."
         }
@@ -1258,13 +1241,13 @@
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "malacytic-conduit"
+            "name": "otherworldly"
           }
         ]
       },
@@ -1275,12 +1258,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "cankers wandering beast base game todo todo - image too small to read unknown-icon unknown-icon"
+      "searchText": "cankers wandering beast base game wandering beast disquiet-dismay place a pack of cankers at a random entry point and activate them immediately. these characters follow normal npc activation rules considering all other characters to be enemies. however, if unengaged they will target the closest enemy with magic pegs, if possible. desperation-doom as above, but flip the cankers’ character board to the elite side. wandering-beast otherworldly"
     },
     {
       "id": 31,
@@ -1295,8 +1278,7 @@
         {
           "kind": "mode",
           "label": "DISQUIET-DISMAY",
-          "text": "Place a Troglodyte at a random Entry Point and activate it immediately.",
-          "threshold": 1
+          "text": "Place a Troglodyte at a random Entry Point and activate it immediately."
         },
         {
           "kind": "box",
@@ -1306,15 +1288,14 @@
         {
           "kind": "mode",
           "label": "DESPERATION-DOOM",
-          "text": "As above, but flip the Troglodyte’s character board to the Elite side.",
-          "threshold": 7
+          "text": "As above, but flip the Troglodyte’s character board to the Elite side."
         }
       ],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": []
@@ -1326,12 +1307,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "troglodyte wandering beast base game wandering beast disquiet-dismay place a troglodyte at a random entry point and activate it immediately. this character follows normal npc activation rules, considering all other characters to be enemies, with the following exceptions: if the troglodyte is unengaged in an unsearched empty room, it will search the room. if the troglodyte is unengaged within short range and los of a loose item, it will move towards the item and spend an action to pick it up. place items found on this card (no limit). they are dropped if the troglodyte is defeated. desperation-doom as above, but flip the troglodyte’s character board to the elite side. creature"
+      "searchText": "troglodyte wandering beast base game wandering beast disquiet-dismay place a troglodyte at a random entry point and activate it immediately. this character follows normal npc activation rules, considering all other characters to be enemies, with the following exceptions: if the troglodyte is unengaged in an unsearched empty room, it will search the room. if the troglodyte is unengaged within short range and los of a loose item, it will move towards the item and spend an action to pick it up. place items found on this card (no limit). they are dropped if the troglodyte is defeated. desperation-doom as above, but flip the troglodyte’s character board to the elite side. wandering-beast"
     },
     {
       "id": 32,
@@ -1350,7 +1331,7 @@
         },
         {
           "kind": "box",
-          "label": "Note",
+          "label": "",
           "text": "This character follows normal NPC activation rules considering all other characters to be enemies."
         },
         {
@@ -1363,7 +1344,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": []
@@ -1375,12 +1356,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "drakon wandering beast base game todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "drakon wandering beast base game wandering beast disquiet-dismay place a drakon at a random entry point and activate it immediately. this character follows normal npc activation rules considering all other characters to be enemies. disaster-doom as above, but flip the drakon’s character board to the elite side. wandering-beast"
     },
     {
       "id": 33,
@@ -1402,7 +1383,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -1412,12 +1393,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.95,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "trap! net dungeon base game disquiet-doom with a twang followed by the sound of ropes clattering through pulleys, an adventurer finds themselves suspended from the ceiling in a net. choose a random adventurer. they may spend a skill peg (reaction) to dodge the net. if they do not, place a net marker on the adventurer and they become fatigued. the net remains in play, following the normal rules. entry-point"
+      "searchText": "trap! net dungeon base game disquiet-doom with a twang followed by the sound of ropes clattering through pulleys, an adventurer finds themselves suspended from the ceiling in a net. choose a random adventurer. they may spend a skill peg (reaction) to dodge the net. if they do not, place a net marker on the adventurer and they become fatigued. the net remains in play, following the normal rules. dungeon"
     },
     {
       "id": 34,
@@ -1439,7 +1420,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -1449,12 +1430,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.95,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "trap! pit dungeon base game todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "trap! pit dungeon base game disquiet-doom an adventurer steps on a suspicious flagstone and it falls through! select a random adventurer and place a pit terrain piece in contact with them, or in the closest possible position not in contact with an entry point (it can be placed under other characters). any character on the pit falls in. any character in contact with the pit must spend a skill peg (reaction) or fall in. the pit remains in play, following the normal rules. dungeon"
     },
     {
       "id": 35,
@@ -1476,7 +1457,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "wall"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -1486,12 +1467,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.95,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "trap! swinging blade dungeon base game disquiet-doom an adventurer knocks a loose brick and sets off a swinging blade. a random adventurer must spend a skill peg (reaction) or suffer a three-dice attack with sharp sharp . add the swinging blade terrain piece to the nearest available position on a wall and place 5 reminder counters on top. the blade remains in play, following the normal rules. wall"
+      "searchText": "trap! swinging blade dungeon base game disquiet-doom an adventurer knocks a loose brick and sets off a swinging blade. a random adventurer must spend a skill peg (reaction) or suffer a three-dice attack with sharp sharp . add the swinging blade terrain piece to the nearest available position on a wall and place 5 reminder counters on top. the blade remains in play, following the normal rules. dungeon"
     },
     {
       "id": 36,
@@ -1505,28 +1486,25 @@
       "sections": [
         {
           "kind": "mode",
-          "label": "Disquiet",
-          "text": "Select a random Adventurer. Place a Darkness counter in the closest room to them without one.\n\nIf Darkness rules are in effect, instead remove the closest Light counter or sconce.",
-          "threshold": 1
+          "label": "DISQUIET",
+          "text": "Select a random Adventurer. Place a Darkness counter in the closest room to them without one.\n\nIf Darkness rules are in effect, instead remove the closest Light counter or sconce."
         },
         {
-          "kind": "body",
-          "label": "Distress-Dismay",
-          "text": "Select a random Adventurer. Place Darkness counters in the two closest rooms without any.\n\nIf Darkness rules are in effect, instead remove the two closest Light counters or sconces.",
-          "threshold": 7
+          "kind": "mode",
+          "label": "DISTRESS-DISMAY",
+          "text": "Select a random Adventurer. Place Darkness counters in the two closest rooms without any.\n\nIf Darkness rules are in effect, instead remove the two closest Light counters or sconces."
         },
         {
-          "kind": "body",
-          "label": "Desperation-Doom",
-          "text": "Select a random Adventurer. Place Darkness counters in the three closest rooms without any.\n\nIf Darkness rules are in effect, instead remove the three closest Light counters or sconces.",
-          "threshold": 13
+          "kind": "mode",
+          "label": "DESPERATION-DOOM",
+          "text": "Select a random Adventurer. Place Darkness counters in the three closest rooms without any.\n\nIf Darkness rules are in effect, instead remove the three closest Light counters or sconces."
         }
       ],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -1536,12 +1514,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.95,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "fading light dungeon base game todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "fading light dungeon base game disquiet select a random adventurer. place a darkness counter in the closest room to them without one. if darkness rules are in effect, instead remove the closest light counter or sconce. distress-dismay select a random adventurer. place darkness counters in the two closest rooms without any. if darkness rules are in effect, instead remove the two closest light counters or sconces. desperation-doom select a random adventurer. place darkness counters in the three closest rooms without any. if darkness rules are in effect, instead remove the three closest light counters or sconces. dungeon"
     },
     {
       "id": 37,
@@ -1555,12 +1533,12 @@
       "sections": [
         {
           "kind": "mode",
-          "label": "Disquiet-Dismay",
+          "label": "DISQUIET-DISMAY",
           "text": "Your movement has caused the ancient walls and ceilings to crumble. Increase the Dread by 1.\n\nDetermine the Adventurer furthest from their Staging Point. Scatter from their position, ignoring terrain, and place two Barricades – one high and one low – in the closest possible position to that point (they can be placed under characters). Any characters in those squares must spend a Skill peg (reaction) or suffer a three dice attack with Bludgeoning [bludgeoning]. The characters are then moved to the nearest empty square."
         },
         {
           "kind": "mode",
-          "label": "Desperation-Doom",
+          "label": "DESPERATION-DOOM",
           "text": "As above, but determine the Adventurer closest to their Staging Point."
         }
       ],
@@ -1568,7 +1546,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -1578,12 +1556,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.95,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "collapse! dungeon base game todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "collapse! dungeon base game disquiet-dismay your movement has caused the ancient walls and ceilings to crumble. increase the dread by 1. determine the adventurer furthest from their staging point. scatter from their position, ignoring terrain, and place two barricades – one high and one low – in the closest possible position to that point (they can be placed under characters). any characters in those squares must spend a skill peg (reaction) or suffer a three dice attack with bludgeoning bludgeoning . the characters are then moved to the nearest empty square. desperation-doom as above, but determine the adventurer closest to their staging point. dungeon"
     },
     {
       "id": 38,
@@ -1597,12 +1575,12 @@
       "sections": [
         {
           "kind": "mode",
-          "label": "Disquiet-Dismay",
+          "label": "DISQUIET-DISMAY",
           "text": "Latent Maladum energy awakens the remnants of a long-dead warrior. The tomb closest to an Adventurer is opened (if not already) and a Myria is placed in contact with it (even if Revenant Adversaries are not being used). A random item inside the tomb is fused with the creature's body – place it on the Myria's base. It will be dropped when the creature is defeated.\n\nIf no Myria can be placed, raise the Dread by 1."
         },
         {
           "kind": "mode",
-          "label": "Desperation-Doom",
+          "label": "DESPERATION-DOOM",
           "text": "As above, but the effect applies to all Tombs in play. Raise the Dread by 1 for each Myria that cannot be placed."
         }
       ],
@@ -1610,7 +1588,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "grave"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -1620,12 +1598,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.95,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "dormant lifeforce dungeon base game disquiet-dismay latent maladum energy awakens the remnants of a long-dead warrior. the tomb closest to an adventurer is opened (if not already) and a myria is placed in contact with it (even if revenant adversaries are not being used). a random item inside the tomb is fused with the creature's body – place it on the myria's base. it will be dropped when the creature is defeated. if no myria can be placed, raise the dread by 1. desperation-doom as above, but the effect applies to all tombs in play. raise the dread by 1 for each myria that cannot be placed. grave"
+      "searchText": "dormant lifeforce dungeon base game disquiet-dismay latent maladum energy awakens the remnants of a long-dead warrior. the tomb closest to an adventurer is opened (if not already) and a myria is placed in contact with it (even if revenant adversaries are not being used). a random item inside the tomb is fused with the creature's body – place it on the myria's base. it will be dropped when the creature is defeated. if no myria can be placed, raise the dread by 1. desperation-doom as above, but the effect applies to all tombs in play. raise the dread by 1 for each myria that cannot be placed. dungeon"
     },
     {
       "id": 39,
@@ -1657,7 +1635,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -1667,12 +1645,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "drip, drip, drip dungeon base game todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "drip, drip, drip dungeon base game disquiet-dismay dungeons are damp and often become waterlogged after rain due to poor construction. choose a random adventurer – the room they are in, and two random connected rooms, become wet and slippery. mark the rooms with a reminder counter. add a purple peg to the dread tracker in the last space of the band beyond the current one. all move actions that end within one of these rooms risk falling. roll a die; on a skull lay the character prone. every square in the room is a source of water. in each assessment phase, roll a die for each sconce and torch in this area. on a skull , remove it. when the purple peg is replaced, discard this card and the associated reminder counters. desperation-doom as above, but do not add a purple peg – the effects last until the end of the game. dungeon"
     },
     {
       "id": 40,
@@ -1699,7 +1677,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "novice"
           }
         ],
         "right": []
@@ -1709,12 +1687,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "premonition novice base game todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "premonition novice base game disquiet-doom the first player selects one of their adventurers at random. they become fatigued as magical energy washes over them and they are bombarded by visions. the first player keeps this card. discard it during any future dread phase after an event card is drawn to place the event card back onto the deck without resolving it. novice"
     },
     {
       "id": 41,
@@ -1736,7 +1714,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "novice"
           }
         ],
         "right": []
@@ -1746,12 +1724,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "teamwork novice base game todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "teamwork novice base game disquiet-doom the first player keeps this card, without showing the other players. your party have spent their downtime training hard, learning each other’s strengths and covering each other’s weaknesses. it’s time for that training to pay off! discard this card during any of your turns to choose one of your adventurers. that adventurer and all others from your party within short range and/or los may take one action, in any order. skills may be used as if it was their turn. this action does not impact their activation this round, and stunned and terrified characters cannot act. novice"
     },
     {
       "id": 42,
@@ -1773,7 +1751,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "novice"
           }
         ],
         "right": []
@@ -1783,12 +1761,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "respite novice base game disquiet-doom there is an unexpected lull in the seemingly endless onslaught. reduce dread by 2. no adversaries will arrive this round. adventurers already in play will activate as normal. unknown-icon unknown-icon"
+      "searchText": "respite novice base game disquiet-doom there is an unexpected lull in the seemingly endless onslaught. reduce dread by 2. no adversaries will arrive this round. adversaries already in play will activate as normal. novice"
     },
     {
       "id": 43,
@@ -1803,14 +1781,14 @@
         {
           "kind": "mode",
           "label": "DISQUIET-DOOM",
-          "text": "The first player keeps this card, without showing the other players.\n\nYou may discard this card at the start of one of your Adventurer’s turns if they have at least three enemies in short range.\n\nAll of that Adventurer’s attacks this turn roll one additional die and gain Vicious [sharp], Quickstrike [move], and Cleave [melee] in addition to their normal effects."
+          "text": "The first player keeps this card, without showing the other players.\n\nYou may discard this card at the start of one of your Adventurer’s turns if they have at least three enemies in short range.\n\nAll of that Adventurer’s attacks this turn roll one additional die and gain Vicious [vicious], Quickstrike [quickstrike], and Cleave [cleave] in addition to their normal effects."
         }
       ],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "novice"
           }
         ],
         "right": []
@@ -1820,12 +1798,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "blaze of glory novice base game todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "blaze of glory novice base game disquiet-doom the first player keeps this card, without showing the other players. you may discard this card at the start of one of your adventurer’s turns if they have at least three enemies in short range. all of that adventurer’s attacks this turn roll one additional die and gain vicious vicious , quickstrike quickstrike , and cleave cleave in addition to their normal effects. novice"
     },
     {
       "id": 44,
@@ -1847,7 +1825,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "novice"
           }
         ],
         "right": []
@@ -1859,12 +1837,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "spurred on novice base game todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "spurred on novice base game novice disquiet-doom reduce dread by 1. the adventurers are galvanised by a sudden spurt of energy. starting with the first player, all adventurers in play may either remove a status counter of their choice or take one action. novice"
     },
     {
       "id": 45,
@@ -1886,7 +1864,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "novice"
           }
         ],
         "right": []
@@ -1896,12 +1874,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "malacytic surge novice base game todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "malacytic surge novice base game disquiet-doom reduce dread by 1. a surge of power awakens the malacytes in the adventurers. all adventurers in play restore two magic pegs. if they are already at their maximum they become blessed for each peg they didn’t restore. novice"
     },
     {
       "id": 46,
@@ -1923,11 +1901,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
-          },
-          {
-            "type": "icon",
-            "name": "larger-area"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -1939,12 +1913,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "dangerous ground veteran base game todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "dangerous ground veteran base game veteran disquiet-doom increase dread by 1. a chasm opens up beneath the adventurers’ feet! select a random adventurer and place a pit terrain piece in the closest possible position to them, under them if possible, that is not in contact with an entry point. any character on the pit falls in. any character in contact with the pit must spend a skill peg (reaction) or fall in. the pit remains in play, following the normal rules. veteran"
     },
     {
       "id": 47,
@@ -1966,11 +1940,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
-          },
-          {
-            "type": "icon",
-            "name": "entry-point"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -1982,12 +1952,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "malacytic exhaustion veteran base game todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "malacytic exhaustion veteran base game veteran disquiet-doom increase dread by 1. an almost tangible wave of energy passes through the area, draining the adventurers’ power. all adventurers in play discard two magic pegs. if they reach zero they become fatigued for each peg they were unable to discard. veteran"
     },
     {
       "id": 48,
@@ -2002,15 +1972,14 @@
         {
           "kind": "mode",
           "label": "DISQUIET-DOOM",
-          "text": "Increase Dread by 1.\nAll Adversaries in play immediately activate following the normal rules. They will activate again in the Adversary Phase.",
-          "threshold": 2
+          "text": "Increase Dread by 1.\nAll Adversaries in play immediately activate following the normal rules. They will activate again in the Adversary Phase."
         }
       ],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -2022,12 +1991,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "unexpected assault veteran base game todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "unexpected assault veteran base game veteran disquiet-doom increase dread by 1. all adversaries in play immediately activate following the normal rules. they will activate again in the adversary phase. veteran"
     },
     {
       "id": 49,
@@ -2042,18 +2011,14 @@
         {
           "kind": "mode",
           "label": "DISQUIET-DOOM",
-          "text": "Increase Dread by 2. Then, draw and resolve another Event Card. If the newly drawn card is a [arrow-up] card, discard it with no effect instead of resolving it."
+          "text": "Increase Dread by 2. Then, draw and resolve another Event Card. If the newly drawn card is a [veteran] card, discard it with no effect instead of resolving it."
         }
       ],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
-          },
-          {
-            "type": "icon",
-            "name": "entry-point"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -2065,12 +2030,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "one thing after another veteran base game todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "one thing after another veteran base game veteran disquiet-doom increase dread by 2. then, draw and resolve another event card. if the newly drawn card is a veteran card, discard it with no effect instead of resolving it. veteran"
     },
     {
       "id": 50,
@@ -2088,7 +2053,7 @@
           "text": "Increase Dread by 1 and shuffle this card back into the deck."
         },
         {
-          "kind": "body",
+          "kind": "mode",
           "label": "DISTRESS-DOOM",
           "text": "Increase Dread by 1.\n\nYour Adventurers have disturbed some fresh graves and awoken their inhabitants from their slumber.\n\nPlace four Grave Point markers as close as possible to the last place Searched (the Search Counter in the case of a general Search). If no Searches have been made this game, place the Grave Point markers as close as possible to the Adventurer furthest from their Staging Point."
         }
@@ -2097,7 +2062,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "grave"
+            "name": "revenant"
           },
           {
             "type": "label",
@@ -2105,7 +2070,7 @@
           },
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -2115,12 +2080,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "fresh graves revenant + veteran base game todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "fresh graves revenant + veteran base game disquiet increase dread by 1 and shuffle this card back into the deck. distress-doom increase dread by 1. your adventurers have disturbed some fresh graves and awoken their inhabitants from their slumber. place four grave point markers as close as possible to the last place searched (the search counter in the case of a general search). if no searches have been made this game, place the grave point markers as close as possible to the adventurer furthest from their staging point. revenant + veteran"
     },
     {
       "id": 128,
@@ -2142,7 +2107,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -2157,7 +2122,7 @@
         "issues": [],
         "managedBy": "human"
       },
-      "searchText": "careless swing veteran base game disquiet-doom your adventurers are becoming overconfident and are not paying their full attention to the ongoing fighting. add a purple peg to the dread tracker 5 spaces ahead of the current dread. until that peg is replaced, each time an adventurer makes an attack, if they roll two blunders skull their weapon breaks. unarmed attackers become fatigued. (this effect applies to all attacks not just forceful hits). arrow-up"
+      "searchText": "careless swing veteran base game disquiet-doom your adventurers are becoming overconfident and are not paying their full attention to the ongoing fighting. add a purple peg to the dread tracker 5 spaces ahead of the current dread. until that peg is replaced, each time an adventurer makes an attack, if they roll two blunders skull their weapon breaks. unarmed attackers become fatigued. (this effect applies to all attacks not just forceful hits). veteran"
     },
     {
       "id": 129,
@@ -2179,7 +2144,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -2194,7 +2159,7 @@
         "issues": [],
         "managedBy": "human"
       },
-      "searchText": "deadly accuracy veteran base game disquiet-doom whether by sheer luck or unnatural guidance your adversaries strike with unnerving accuracy. this round, all adversaries gain piercing piercing . shuffle this card back into the deck instead of discarding. arrow-up"
+      "searchText": "deadly accuracy veteran base game disquiet-doom whether by sheer luck or unnatural guidance your adversaries strike with unnerving accuracy. this round, all adversaries gain piercing piercing . shuffle this card back into the deck instead of discarding. veteran"
     },
     {
       "id": 130,
@@ -2221,7 +2186,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           },
           {
             "type": "label",
@@ -2229,7 +2194,7 @@
           },
           {
             "type": "icon",
-            "name": "wall"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -2244,7 +2209,7 @@
         "issues": [],
         "managedBy": "human"
       },
-      "searchText": "trap! fireball veteran + dungeon base game disquiet-dismay with a soft \"click\", an adventurer steps on a loose stone that sinks into the floor. a random adventurer suffers a ranged attack with two dice and burning fire . desperation-doom as disquiet-dismay but the adventurer suffers a three dice attack with blast and burning fire . arrow-up + wall"
+      "searchText": "trap! fireball veteran + dungeon base game disquiet-dismay with a soft \"click\", an adventurer steps on a loose stone that sinks into the floor. a random adventurer suffers a ranged attack with two dice and burning fire . desperation-doom as disquiet-dismay but the adventurer suffers a three dice attack with blast and burning fire . veteran + dungeon"
     },
     {
       "id": 131,
@@ -2271,7 +2236,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -2286,7 +2251,7 @@
         "issues": [],
         "managedBy": "human"
       },
-      "searchText": "wave of exhaustion veteran base game disquiet-distress your adventurers are beset by an unshakable tiredness. each adventurer must spend a skill peg or become fatigued. dismay-doom as disquiet-distress but adventurers must spend two skill pegs, gaining one fatigue for each peg not spent. arrow-up"
+      "searchText": "wave of exhaustion veteran base game disquiet-distress your adventurers are beset by an unshakable tiredness. each adventurer must spend a skill peg or become fatigued. dismay-doom as disquiet-distress but adventurers must spend two skill pegs, gaining one fatigue for each peg not spent. veteran"
     },
     {
       "id": 132,
@@ -2318,7 +2283,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           },
           {
             "type": "label",
@@ -2326,7 +2291,7 @@
           },
           {
             "type": "icon",
-            "name": "wall"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -2341,7 +2306,7 @@
         "issues": [],
         "managedBy": "human"
       },
-      "searchText": "trap! poison gas veteran + dungeon base game disquiet a faint hissing sound fills the air. too late you realise a noxious gas is pouring into the room. roll the magic die. mark the grave point closest to the entry point that matches the roll with a poison counter. for the rest of the game, any time an adventurer ends their turn within short range of this grave point must spend a skill peg or become poisoned poison . the gas can be stopped by covering the grave point with a crate, chest, or similar item. (do not remove the poison counter. if the grave point is unblocked, the gas will start again). distress-dismay as disquiet, but mark two grave points. if a duplicate grave point is chosen, mark the next nearest. desperation-doom as disquiet but mark four grave points. if a duplicate grave point is chosen, mark the next nearest. arrow-up + wall"
+      "searchText": "trap! poison gas veteran + dungeon base game disquiet a faint hissing sound fills the air. too late you realise a noxious gas is pouring into the room. roll the magic die. mark the grave point closest to the entry point that matches the roll with a poison counter. for the rest of the game, any time an adventurer ends their turn within short range of this grave point must spend a skill peg or become poisoned poison . the gas can be stopped by covering the grave point with a crate, chest, or similar item. (do not remove the poison counter. if the grave point is unblocked, the gas will start again). distress-dismay as disquiet, but mark two grave points. if a duplicate grave point is chosen, mark the next nearest. desperation-doom as disquiet but mark four grave points. if a duplicate grave point is chosen, mark the next nearest. veteran + dungeon"
     },
     {
       "id": 133,
@@ -2356,19 +2321,14 @@
         {
           "kind": "mode",
           "label": "DISQUIET-DOOM",
-          "text": "The air around you smells rotten and is thick with the odour of decaying food.\n\nRoll one die for each food item carried by each Adventurer. On a Blunder [skull] discard that item.\n\nThese items are considered food:"
-        },
-        {
-          "kind": "note",
-          "label": "Note",
-          "text": "The printed card defines the affected food items with item art. Refer to the source image for the exact list."
+          "text": "The air around you smells rotten and is thick with the odour of decaying food.\n\nRoll one die for each food item carried by each Adventurer. On a Blunder [skull] discard that item.\n\nThese items are considered food: Morsel, Provisions, Remedy, Minerals, Sunblessed Weed, Herbs, and Fungus."
         }
       ],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -2378,14 +2338,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "needs-review",
-        "confidence": 0.8,
-        "issues": [
-          "Food item list is still represented by item art in the source image."
-        ],
+        "status": "verified",
+        "confidence": 1,
+        "issues": [],
         "managedBy": "human"
       },
-      "searchText": "sudden rot veteran base game disquiet-doom the air around you smells rotten and is thick with the odour of decaying food. roll one die for each food item carried by each adventurer. on a blunder skull discard that item. these items are considered food: note the printed card defines the affected food items with item art. refer to the source image for the exact list. arrow-up"
+      "searchText": "sudden rot veteran base game disquiet-doom the air around you smells rotten and is thick with the odour of decaying food. roll one die for each food item carried by each adventurer. on a blunder skull discard that item. these items are considered food: morsel provisions remedy minerals sunblessed weed herbs fungus veteran"
     },
     {
       "id": 134,
@@ -2400,7 +2358,7 @@
         {
           "kind": "mode",
           "label": "DISQUIET-DISTRESS",
-          "text": "Your adversaries attack with increased strength and fervour.\n\nAdd a purple peg to the Dread tracker 5 spaces ahead of the current Dread.\n\nUntil that peg is replaced, all Adversary attacks have Sundering.\n\nAfter the peg is replaced, discard this card."
+          "text": "Your adversaries attack with increased strength and fervour.\n\nAdd a purple peg to the Dread tracker 5 spaces ahead of the current Dread.\n\nUntil that peg is replaced, all Adversary attacks have Sundering [sundering].\n\nAfter the peg is replaced, discard this card."
         },
         {
           "kind": "mode",
@@ -2412,7 +2370,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -2427,7 +2385,7 @@
         "issues": [],
         "managedBy": "human"
       },
-      "searchText": "malacytic vigour veteran base game disquiet-distress your adversaries attack with increased strength and fervour. add a purple peg to the dread tracker 5 spaces ahead of the current dread. until that peg is replaced, all adversary attacks have sundering. after the peg is replaced, discard this card. dismay-doom as disquiet-distress but place the purple peg 10 spaces ahead of the current dread. arrow-up"
+      "searchText": "malacytic vigour veteran base game disquiet-distress your adversaries attack with increased strength and fervour. add a purple peg to the dread tracker 5 spaces ahead of the current dread. until that peg is replaced, all adversary attacks have sundering sundering . after the peg is replaced, discard this card. dismay-doom as disquiet-distress but place the purple peg 10 spaces ahead of the current dread. veteran"
     },
     {
       "id": 135,
@@ -2442,7 +2400,7 @@
         {
           "kind": "mode",
           "label": "DISQUIET",
-          "text": "You hear a harsh grinding from behind a wall. Suddenly a large section tips forward almost flattening an Adventurer.\n\nThe Adventurer closest to a wall suffers a three dice attack with Bludgeoning [bludgeoning] and Sundering."
+          "text": "You hear a harsh grinding from behind a wall. Suddenly a large section tips forward almost flattening an Adventurer.\n\nThe Adventurer closest to a wall suffers a three dice attack with Bludgeoning [bludgeoning] and Sundering [sundering]."
         },
         {
           "kind": "mode",
@@ -2454,7 +2412,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           },
           {
             "type": "label",
@@ -2462,7 +2420,7 @@
           },
           {
             "type": "icon",
-            "name": "wall"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -2477,7 +2435,7 @@
         "issues": [],
         "managedBy": "human"
       },
-      "searchText": "trap! deadfall veteran + dungeon base game disquiet you hear a harsh grinding from behind a wall. suddenly a large section tips forward almost flattening an adventurer. the adventurer closest to a wall suffers a three dice attack with bludgeoning bludgeoning and sundering. distress-doom as disquiet but choose the two adventurers closest to a wall. (this does not have to be the same wall) arrow-up + wall"
+      "searchText": "trap! deadfall veteran + dungeon base game disquiet you hear a harsh grinding from behind a wall. suddenly a large section tips forward almost flattening an adventurer. the adventurer closest to a wall suffers a three dice attack with bludgeoning bludgeoning and sundering sundering . distress-doom as disquiet but choose the two adventurers closest to a wall. (this does not have to be the same wall) veteran + dungeon"
     },
     {
       "id": 136,
@@ -2499,7 +2457,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -2514,7 +2472,7 @@
         "issues": [],
         "managedBy": "human"
       },
-      "searchText": "crack! veteran base game disquiet-doom select an adventurer at random. a random item that they are carrying is broken (including those in an armour slot). turn the item face down. arrow-up"
+      "searchText": "crack! veteran base game disquiet-doom select an adventurer at random. a random item that they are carrying is broken (including those in an armour slot). turn the item face down. veteran"
     },
     {
       "id": 137,
@@ -2541,7 +2499,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -2556,7 +2514,7 @@
         "issues": [],
         "managedBy": "human"
       },
-      "searchText": "get them off me! veteran base game disquiet-dismay a swarm of tiny insects pours out of the wall. they are in your hair, under your armour, in your shoes... everywhere! select a random adventurer. scatter all items in that adventurer's armour slot. that adventurer becomes fatigued. if no adventurers are wearing items, increase dread by 1 and shuffle this card back into the deck. desperation-doom as disquiet-dismay but all adventurers must resolve the effect. arrow-up"
+      "searchText": "get them off me! veteran base game disquiet-dismay a swarm of tiny insects pours out of the wall. they are in your hair, under your armour, in your shoes... everywhere! select a random adventurer. scatter all items in that adventurer's armour slot. that adventurer becomes fatigued. if no adventurers are wearing items, increase dread by 1 and shuffle this card back into the deck. desperation-doom as disquiet-dismay but all adventurers must resolve the effect. veteran"
     },
     {
       "id": 138,
@@ -2578,7 +2536,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -2593,7 +2551,7 @@
         "issues": [],
         "managedBy": "human"
       },
-      "searchText": "where did i put that? veteran base game disquiet-doom you are sure you had it on you, you are 100% certain that it was in your pack, but it is nowhere to be found. select an adventurer at random. they discard their smallest item (including those in an armour slot). arrow-up"
+      "searchText": "where did i put that? veteran base game disquiet-doom you are sure you had it on you, you are 100% certain that it was in your pack, but it is nowhere to be found. select an adventurer at random. they discard their smallest item (including those in an armour slot). veteran"
     },
     {
       "id": 139,
@@ -2608,14 +2566,14 @@
         {
           "kind": "mode",
           "label": "DISQUIET-DOOM",
-          "text": "You are overcome with an uneasy feeling of Deja vu and impending doom.\n\nResolve the top Veteran [arrow-up] card of the Event Discard pile. If there isn't one, increase the Dread by 2 and shuffle this card back into the deck."
+          "text": "You are overcome with an uneasy feeling of Déjà vu and impending doom.\n\nResolve the top Veteran [veteran] card of the Event Discard pile. If there isn't one, increase the Dread by 2 and shuffle this card back into the deck."
         }
       ],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -2630,7 +2588,7 @@
         "issues": [],
         "managedBy": "human"
       },
-      "searchText": "not again? veteran base game disquiet-doom you are overcome with an uneasy feeling of deja vu and impending doom. resolve the top veteran arrow-up card of the event discard pile. if there isn't one, increase the dread by 2 and shuffle this card back into the deck. arrow-up"
+      "searchText": "not again? veteran base game disquiet-doom you are overcome with an uneasy feeling of déjà vu and impending doom. resolve the top veteran veteran card of the event discard pile. if there isn't one, increase the dread by 2 and shuffle this card back into the deck. veteran"
     },
     {
       "id": 140,
@@ -2657,7 +2615,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -2672,7 +2630,7 @@
         "issues": [],
         "managedBy": "human"
       },
-      "searchText": "trap! acid mist veteran base game disquiet-dismay a fine mist seeps out of the ground around you. as it settles on your equipment it begins to hiss. each adventurer suffers a two dice ranged attack with piercing piercing . if any of these attacks roll a critical hit, a random item held by the target (including items in the armour slot) is broken. desperation-doom as disquiet-dismay, but the effect applies if any hits are scored, not just on a critical hit. arrow-up"
+      "searchText": "trap! acid mist veteran base game disquiet-dismay a fine mist seeps out of the ground around you. as it settles on your equipment it begins to hiss. each adventurer suffers a two dice ranged attack with piercing piercing . if any of these attacks roll a critical hit, a random item held by the target (including items in the armour slot) is broken. desperation-doom as disquiet-dismay, but the effect applies if any hits are scored, not just on a critical hit. veteran"
     },
     {
       "id": 141,
@@ -2699,7 +2657,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           },
           {
             "type": "label",
@@ -2707,7 +2665,7 @@
           },
           {
             "type": "icon",
-            "name": "wall"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -2722,7 +2680,7 @@
         "issues": [],
         "managedBy": "human"
       },
-      "searchText": "trap! wall of fire veteran + dungeon base game disquiet a sheet of flame erupts from hidden spouts around a nearby entrance. mark the entrance nearest to a random adventurer with a reminder counter and add a purple peg to the dread tracker at the end of distress. until that peg is replaced, any adventurer that passes through the entrance suffer a one die attack with piercing piercing and is burning fire . after the peg is replaced, discard this card. distress-doom as disquiet but add a purple peg to the dread tracker at the end of the section two higher than the current dread. arrow-up + wall"
+      "searchText": "trap! wall of fire veteran + dungeon base game disquiet a sheet of flame erupts from hidden spouts around a nearby entrance. mark the entrance nearest to a random adventurer with a reminder counter and add a purple peg to the dread tracker at the end of distress. until that peg is replaced, any adventurer that passes through the entrance suffer a one die attack with piercing piercing and is burning fire . after the peg is replaced, discard this card. distress-doom as disquiet but add a purple peg to the dread tracker at the end of the section two higher than the current dread. veteran + dungeon"
     },
     {
       "id": 142,
@@ -2737,14 +2695,14 @@
         {
           "kind": "mode",
           "label": "DISQUIET-DOOM",
-          "text": "Hundreds of tiny, spiked metal balls fall from the ceiling.\n\nSelect a random Adventurer. Each Adventurer in the same room must spend a Skill peg or become Wounded.\n\nMark the room with a Reminder token.\n\nUntil the end of the game, any Adventurer that moves in that room must roll a die. On a Blunder [skull] they must spend a Skill peg or become Wounded."
+          "text": "Hundreds of tiny, spiked metal balls fall from the ceiling.\n\nSelect a random Adventurer. Each Adventurer in the same room must spend a Skill peg or become Wounded [wounded].\n\nMark the room with a Reminder token.\n\nUntil the end of the game, any Adventurer that moves in that room must roll a die. On a Blunder [skull] they must spend a Skill peg or become Wounded [wounded]."
         }
       ],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           },
           {
             "type": "label",
@@ -2752,7 +2710,7 @@
           },
           {
             "type": "icon",
-            "name": "wall"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -2767,7 +2725,7 @@
         "issues": [],
         "managedBy": "human"
       },
-      "searchText": "trap! caltrops veteran + dungeon base game disquiet-doom hundreds of tiny, spiked metal balls fall from the ceiling. select a random adventurer. each adventurer in the same room must spend a skill peg or become wounded. mark the room with a reminder token. until the end of the game, any adventurer that moves in that room must roll a die. on a blunder skull they must spend a skill peg or become wounded. arrow-up + wall"
+      "searchText": "trap! caltrops veteran + dungeon base game disquiet-doom hundreds of tiny, spiked metal balls fall from the ceiling. select a random adventurer. each adventurer in the same room must spend a skill peg or become wounded wounded . mark the room with a reminder token. until the end of the game, any adventurer that moves in that room must roll a die. on a blunder skull they must spend a skill peg or become wounded wounded . veteran + dungeon"
     }
   ]
 }

--- a/data/cards/beasts-of-environ.json
+++ b/data/cards/beasts-of-environ.json
@@ -18,7 +18,7 @@
         },
         {
           "kind": "body",
-          "label": "Body",
+          "label": "",
           "text": "These characters follow normal NPC activation rules considering all non-Revenant characters to be enemies.\n\nHowever, if unengaged they will target the enemy in LoS furthest from any friendly characters.\n\nWhen all Split-Tail Rats in play are defeated, shuffle this card back into the Event Deck."
         },
         {
@@ -31,7 +31,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": []
@@ -43,12 +43,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "split-tail rats wandering beast beasts of environ todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "split-tail rats wandering beast beasts of environ wandering beast disquiet-dismay place a pack of split-tail rats at a random entry point and activate them immediately. these characters follow normal npc activation rules considering all non-revenant characters to be enemies. however, if unengaged they will target the enemy in los furthest from any friendly characters. when all split-tail rats in play are defeated, shuffle this card back into the event deck. desperation-doom as above, but flip the split-tail rats’ character board to the elite side. wandering-beast"
     },
     {
       "id": 90,
@@ -67,11 +67,11 @@
         },
         {
           "kind": "note",
-          "label": "Note",
+          "label": "",
           "text": "This character follows normal NPC activation rules considering all other characters to be enemies."
         },
         {
-          "kind": "body",
+          "kind": "mode",
           "label": "DESPERATION-DOOM",
           "text": "As above, but flip the Alary's character board to the Elite side."
         }
@@ -80,13 +80,13 @@
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "otherworldly"
           }
         ]
       },
@@ -97,12 +97,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "alary wandering beast beasts of environ todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "alary wandering beast beasts of environ wandering beast disquiet-dismay place an alary at a random entry point and activate it immediately. this character follows normal npc activation rules considering all other characters to be enemies. desperation-doom as above, but flip the alary's character board to the elite side. wandering-beast otherworldly"
     },
     {
       "id": 91,
@@ -116,12 +116,12 @@
       "sections": [
         {
           "kind": "mode",
-          "label": "Disquiet-Dismay",
+          "label": "DISQUIET-DISMAY",
           "text": "Place a Great Bear on the gaming area adjacent to a random Entry Point. Flip the Entry Point. Activate the Great Bear immediately.\n\nThe Entry Point is the beast’s lair. While it is flipped, re-roll it for arrival purposes.\n\nThis character follows normal NPC activation rules considering all other characters to be enemies.\n\nHowever, while the Bear does not have LoS to an enemy, it will Move towards its lair and take no further actions.\n\nThe Great Bear adds one die to its attacks made within short range of its lair.\n\nWhen the Great Bear is defeated, flip the Entry Point back again."
         },
         {
           "kind": "mode",
-          "label": "Desperation-Doom",
+          "label": "DESPERATION-DOOM",
           "text": "As above, but flip the Great Bear’s character board to the Elite side."
         }
       ],
@@ -129,7 +129,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": []
@@ -139,12 +139,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.95,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "great bear wandering beast beasts of environ todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "great bear wandering beast beasts of environ disquiet-dismay place a great bear on the gaming area adjacent to a random entry point. flip the entry point. activate the great bear immediately. the entry point is the beast’s lair. while it is flipped, re-roll it for arrival purposes. this character follows normal npc activation rules considering all other characters to be enemies. however, while the bear does not have los to an enemy, it will move towards its lair and take no further actions. the great bear adds one die to its attacks made within short range of its lair. when the great bear is defeated, flip the entry point back again. desperation-doom as above, but flip the great bear’s character board to the elite side. wandering-beast"
     },
     {
       "id": 92,
@@ -171,7 +171,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": []
@@ -183,12 +183,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "bloodwyrm wandering beast beasts of environ todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "bloodwyrm wandering beast beasts of environ wandering beast disquiet-dismay place a bloodwyrm on the closest empty grave point to an adventurer. if grave points are not being used, scatter from a random adventurer, ignoring terrain, and place it in that position. when activated, it will attack any character in range of its attacks. if no enemies are in range it uses its action to withdraw into its tunnel and re-emerge. replace the bloodwyrm with a small pit. if none are available, take one from elsewhere in play. then, roll to scatter, ignoring terrain, and place the bloodwyrm in the closest empty square to the new position. if an enemy is stunned following a bloodwyrm attack they are defeated and removed – they will be left for dead. remove the bloodwyrm from play and shuffle this card back into the deck. pits remain in play following the normal rules. desperation-doom as above, but flip the bloodwyrm’s character board to the elite side. wandering-beast"
     },
     {
       "id": 93,
@@ -207,7 +207,7 @@
         },
         {
           "kind": "box",
-          "label": "Character Rules",
+          "label": "",
           "text": "This character follows normal NPC activation rules considering all other characters to be enemies.\n\nHowever, this character only targets enemies in short range and LoS. If there are none, it will scatter once per action until there are."
         },
         {
@@ -220,13 +220,13 @@
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "malacytic-conduit"
+            "name": "otherworldly"
           }
         ]
       },
@@ -237,12 +237,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "skin shifter wandering beast beasts of environ todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "skin shifter wandering beast beasts of environ wandering beast disquiet-dismay place a skin shifter at a random entry point and activate it immediately. this character follows normal npc activation rules considering all other characters to be enemies. however, this character only targets enemies in short range and los. if there are none, it will scatter once per action until there are. desperation-doom as above, but flip the skin shifter’s character board to the elite side. wandering-beast otherworldly"
     },
     {
       "id": 94,
@@ -261,7 +261,7 @@
         },
         {
           "kind": "box",
-          "label": "NPC Activation Rules",
+          "label": "",
           "text": "This character follows normal NPC activation rules considering all other characters to be enemies."
         },
         {
@@ -274,7 +274,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": []
@@ -286,12 +286,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "crag troll wandering beast beasts of environ todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "crag troll wandering beast beasts of environ wandering beast disquiet-dismay place a crag troll at a random entry point and activate it immediately. this character follows normal npc activation rules considering all other characters to be enemies. desperation-doom as above, but flip the crag troll's character board to the elite side. wandering-beast"
     },
     {
       "id": 95,
@@ -306,14 +306,14 @@
         {
           "kind": "mode",
           "label": "DISQUIET-DOOM",
-          "text": "A concentration of Maladum inside a magical item has leached out into the container housing it, and it is no longer inanimate!\n\nChoose a Searchable terrain piece at random and mark it with a Reminder counter.\n\nFor the rest of the game, treat the terrain piece as a Wandering Beast with the following statistics:\n\n[actions] [move:2] [creature] [armour:2] [health:3] [melee:1]\n\nThis character follows normal NPC activation rules considering all other characters to be enemies.\n\nAny items inside will be dropped when it is defeated."
+          "text": "A concentration of Maladum inside a magical item has leached out into the container housing it, and it is no longer inanimate!\n\nChoose a Searchable terrain piece at random and mark it with a Reminder counter.\n\nFor the rest of the game, treat the terrain piece as a Wandering Beast with the following statistics:\n\n[actions:2] [move:2] [creature] [armour:2] [health:3] [melee:1]\n\nThis character follows normal NPC activation rules considering all other characters to be enemies.\n\nAny items inside will be dropped when it is defeated."
         }
       ],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -325,12 +325,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "it's alive environment beasts of environ todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "it's alive environment beasts of environ environment disquiet-doom a concentration of maladum inside a magical item has leached out into the container housing it, and it is no longer inanimate! choose a searchable terrain piece at random and mark it with a reminder counter. for the rest of the game, treat the terrain piece as a wandering beast with the following statistics: actions 2 move 2 creature armour 2 health 3 melee 1 this character follows normal npc activation rules considering all other characters to be enemies. any items inside will be dropped when it is defeated. environment"
     },
     {
       "id": 96,
@@ -345,14 +345,14 @@
         {
           "kind": "mode",
           "label": "DISQUIET-DOOM",
-          "text": "Your Adversaries have disturbed the lair of a wild beast!\n\nTake all [creature] cards not being used for this game and draw one at random. Resolve it immediately. However, instead of placing the character(s) at a random Entry Point, place them anywhere within short range and LoS of, but not in contact with, an Adversary. If no Adversaries are in play, place it at an Entry Point as normal."
+          "text": "Your Adversaries have disturbed the lair of a wild beast!\n\nTake all [wandering-beast] cards not being used for this game and draw one at random. Resolve it immediately. However, instead of placing the character(s) at a random Entry Point, place them anywhere within short range and LoS of, but not in contact with, an Adversary. If no Adversaries are in play, place it at an Entry Point as normal."
         }
       ],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -362,12 +362,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "home invasion environment beasts of environ todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "home invasion environment beasts of environ disquiet-doom your adversaries have disturbed the lair of a wild beast! take all wandering-beast cards not being used for this game and draw one at random. resolve it immediately. however, instead of placing the character(s) at a random entry point, place them anywhere within short range and los of, but not in contact with, an adversary. if no adversaries are in play, place it at an entry point as normal. environment"
     },
     {
       "id": 97,
@@ -382,7 +382,7 @@
         {
           "kind": "mode",
           "label": "DISQUIET-DOOM",
-          "text": "An Adventurer you’ve encountered on your travels is not who they seem... They are a Skin Shifter in disguise and the illusion is failing!\n\nIf there are no Denizens in play, take all [denizen] cards not being used for this game and draw one at random. Resolve it intermediately. Then shuffle this card back into the deck.\n\nOtherwise, choose a random Denizen in play. Discard its character board and Event Card. It is considered defeated for any relevant rules.\n\nFor the rest of the game, it will use the rules and statistics from the Skin Shifter character board. It will continue to use its original miniature and any Magic and Health pegs in its dashboard. It will carry any equipment in its inventory but will not use it."
+          "text": "An Adventurer you’ve encountered on your travels is not who they seem... They are a Skin Shifter in disguise and the illusion is failing!\n\nIf there are no Denizens in play, take all [denizen] cards not being used for this game and draw one at random. Resolve it immediately. Then shuffle this card back into the deck.\n\nOtherwise, choose a random Denizen in play. Discard its character board and Event Card. It is considered defeated for any relevant rules.\n\nFor the rest of the game, it will use the rules and statistics from the Skin Shifter character board. It will continue to use its original miniature and any Magic and Health pegs in its dashboard. It will carry any equipment in its inventory but will not use it."
         },
         {
           "kind": "box",
@@ -406,12 +406,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "unmasked! denizen beasts of environ denizen disquiet-doom an adventurer you’ve encountered on your travels is not who they seem... they are a skin shifter in disguise and the illusion is failing! if there are no denizens in play, take all denizen cards not being used for this game and draw one at random. resolve it intermediately. then shuffle this card back into the deck. otherwise, choose a random denizen in play. discard its character board and event card. it is considered defeated for any relevant rules. for the rest of the game, it will use the rules and statistics from the skin shifter character board. it will continue to use its original miniature and any magic and health pegs in its dashboard. it will carry any equipment in its inventory but will not use it. this character follows normal npc activation rules considering all other characters to be enemies. however, this character only targets enemies in short range and los. if there are none, it will scatter once per action until there are. denizen"
+      "searchText": "unmasked! denizen beasts of environ denizen disquiet-doom an adventurer you’ve encountered on your travels is not who they seem... they are a skin shifter in disguise and the illusion is failing! if there are no denizens in play, take all denizen cards not being used for this game and draw one at random. resolve it immediately. then shuffle this card back into the deck. otherwise, choose a random denizen in play. discard its character board and event card. it is considered defeated for any relevant rules. for the rest of the game, it will use the rules and statistics from the skin shifter character board. it will continue to use its original miniature and any magic and health pegs in its dashboard. it will carry any equipment in its inventory but will not use it. this character follows normal npc activation rules considering all other characters to be enemies. however, this character only targets enemies in short range and los. if there are none, it will scatter once per action until there are. denizen"
     }
   ]
 }

--- a/data/cards/beyond-the-vaults.json
+++ b/data/cards/beyond-the-vaults.json
@@ -31,13 +31,13 @@
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "location"
           },
           {
             "type": "label",
@@ -53,12 +53,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "tsewer-nami environment beyond the vaults sewers rivers disquiet-distress the waters start to rise. any character standing in or adjacent to water is knocked prone. then place a purple peg into the first space in the dread band above the current one. all squares in a room containing a sewer channel are move 1 and a source of water until the purple peg is replaced. then shuffle this card back into the deck. dismay-doom a surge of water bursts forth, affecting all rooms containing a sewer channel. • characters are knocked prone and suffer an attack with one die. each hit fatigues the character instead of causing damage. if a character is/becomes stunned, remaining hits are treated as an attack with no-defence . • sources of fire are removed/extinguished, and burning counters removed. map entry-point sewers/rivers"
+      "searchText": "tsewer-nami environment beyond the vaults sewers rivers disquiet-distress the waters start to rise. any character standing in or adjacent to water is knocked prone. then place a purple peg into the first space in the dread band above the current one. all squares in a room containing a sewer channel are move 1 and a source of water until the purple peg is replaced. then shuffle this card back into the deck. dismay-doom a surge of water bursts forth, affecting all rooms containing a sewer channel. • characters are knocked prone and suffer an attack with one die. each hit fatigues the character instead of causing damage. if a character is/becomes stunned, remaining hits are treated as an attack with no-defence . • sources of fire are removed/extinguished, and burning counters removed. environment location sewers/rivers"
     },
     {
       "id": 67,
@@ -73,20 +73,20 @@
         {
           "kind": "mode",
           "label": "DISQUIET-DOOM",
-          "text": "Place a Poisoned counter on the sewer channel closest to the edge of the gaming area.\n\nIn each Assessment Phase, it spreads – place a Poisoned counter on the nearest connected sewer channel to the board edge that doesn’t have one. Then, all characters in short range of any channel with a Poisoned counter must roll for the effects as if were Poisoned themselves (a 6 will not remove the counter as it is not on the character).\n\nAdventurers may Interact with a Poisoned sewer channel and either spend two Magic pegs or discard a Blessed Water token to remove Poisoned counters from it and all adjoining channels.\n\nIf all Poisoned counters are removed, discard this card."
+          "text": "Place a Poisoned [poison] counter on the sewer channel closest to the edge of the gaming area.\n\nIn each Assessment Phase, it spreads – place a Poisoned counter on the nearest connected sewer channel to the board edge that doesn’t have one. Then, all characters in short range of any channel with a Poisoned counter must roll for the effects as if were Poisoned themselves (a 6 will not remove the counter as it is not on the character).\n\nAdventurers may Interact with a Poisoned sewer channel and either spend two Magic pegs or discard a Blessed Water token to remove Poisoned counters from it and all adjoining channels.\n\nIf all Poisoned counters are removed, discard this card."
         }
       ],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "location"
           },
           {
             "type": "label",
@@ -99,12 +99,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "toxic waste environment beyond the vaults todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "toxic waste environment beyond the vaults disquiet-doom place a poisoned poison counter on the sewer channel closest to the edge of the gaming area. in each assessment phase, it spreads – place a poisoned counter on the nearest connected sewer channel to the board edge that doesn’t have one. then, all characters in short range of any channel with a poisoned counter must roll for the effects as if were poisoned themselves (a 6 will not remove the counter as it is not on the character). adventurers may interact with a poisoned sewer channel and either spend two magic pegs or discard a blessed water token to remove poisoned counters from it and all adjoining channels. if all poisoned counters are removed, discard this card. environment location sewers"
     },
     {
       "id": 68,
@@ -118,12 +118,12 @@
       "sections": [
         {
           "kind": "mode",
-          "label": "Disquiet-Dismay",
+          "label": "DISQUIET-DISMAY",
           "text": "Determine the square of a lava flow closest to an Adventurer. Scatter two burning counters from that position (placing counters adjacent to the flow if they would land on it). Then, for each party taking part, repeat this process for the next closest lava flow (e.g. a total of twice for a single party, three times for two parties, etc)\n\nIf a counter hits a character or terrain piece, they are Burning. Otherwise, place it on the floor. Squares with a burning counter are treated as lava flows."
         },
         {
           "kind": "mode",
-          "label": "Desperation-Doom",
+          "label": "DESPERATION-DOOM",
           "text": "As Disquiet-Dismay, but scatter three burning counters per lava flow."
         }
       ],
@@ -131,13 +131,13 @@
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "location"
           },
           {
             "type": "label",
@@ -150,12 +150,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "spitting fire environment beyond the vaults todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "spitting fire environment beyond the vaults disquiet-dismay determine the square of a lava flow closest to an adventurer. scatter two burning counters from that position (placing counters adjacent to the flow if they would land on it). then, for each party taking part, repeat this process for the next closest lava flow (e.g. a total of twice for a single party, three times for two parties, etc) if a counter hits a character or terrain piece, they are burning. otherwise, place it on the floor. squares with a burning counter are treated as lava flows. desperation-doom as disquiet-dismay, but scatter three burning counters per lava flow. environment location mines"
     },
     {
       "id": 69,
@@ -182,13 +182,13 @@
         "left": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "dungeon"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "location"
           },
           {
             "type": "label",
@@ -201,12 +201,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "cave-in! dungeon beyond the vaults todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "cave-in! dungeon beyond the vaults disquiet-distress choose a random rockface wall and mark it as destroyed – it no longer produces ore. all characters within short range of the rockface side suffer a two-dice attack with bludgeoning bludgeoning . dismay-doom as disquiet-distress, but there is a risk of a chain reaction! mark all tunnel entrance walls and rockface walls with reminder counters. after a cart or character passes through a tunnel/character interacts with a rockface, roll the blue die (before completing any movement). on a blunder skull the tunnel/rockface collapses. place a barricade on each side of a tunnel/the rockface side of a wall, pushing characters aside. derail the cart if applicable. any character pushed aside suffers a two-dice attack with bludgeoning bludgeoning . mark collapsed rockface walls as destroyed. dungeon location mines"
     },
     {
       "id": 70,
@@ -220,12 +220,12 @@
       "sections": [
         {
           "kind": "mode",
-          "label": "Disquiet-Dismay",
+          "label": "DISQUIET-DISMAY",
           "text": "Select a random Denizen. It gains two Health, a Pick/Hammer or similar and Explosives. Place it at a random Entry Point. When activated, it Moves to the nearest Rockface and Interacts to drop ore. When Dread reaches Desperation, it takes the ore to the nearest cart and drives off the gaming area. It will not engage. If engaged, it makes a Melee Attack. If still engaged it Moves away, or Attacks again if it cannot. It then resumes normal rules. If ore is Interacted with within short range it is hostile to that party and follows the AI chart while enemies are visible. If its equipment is taken, it is hostile to all and leaves play if no enemies are visible."
         },
         {
           "kind": "mode",
-          "label": "Desperation-Doom",
+          "label": "DESPERATION-DOOM",
           "text": "Select a Denizen as above. See above for character interactions. Otherwise, when activated, it Moves to the Mine Entrance and discards Explosives to drop 3 Reminder counters. It then leaves the gaming area. Remove one Reminder in Assessment Phase. When the last is removed, remove any Track passing through the Entrance and place two Barricades blocking it."
         }
       ],
@@ -233,7 +233,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "dungeon"
           },
           {
             "type": "label",
@@ -247,7 +247,7 @@
         "right": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "location"
           },
           {
             "type": "label",
@@ -260,12 +260,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.95,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "heigh-ho, heigh-ho! dungeon + denizen beyond the vaults todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "heigh-ho, heigh-ho! dungeon + denizen beyond the vaults disquiet-dismay select a random denizen. it gains two health, a pick/hammer or similar and explosives. place it at a random entry point. when activated, it moves to the nearest rockface and interacts to drop ore. when dread reaches desperation, it takes the ore to the nearest cart and drives off the gaming area. it will not engage. if engaged, it makes a melee attack. if still engaged it moves away, or attacks again if it cannot. it then resumes normal rules. if ore is interacted with within short range it is hostile to that party and follows the ai chart while enemies are visible. if its equipment is taken, it is hostile to all and leaves play if no enemies are visible. desperation-doom select a denizen as above. see above for character interactions. otherwise, when activated, it moves to the mine entrance and discards explosives to drop 3 reminder counters. it then leaves the gaming area. remove one reminder in assessment phase. when the last is removed, remove any track passing through the entrance and place two barricades blocking it. dungeon + denizen location mines"
     },
     {
       "id": 71,
@@ -287,13 +287,13 @@
         "left": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "dungeon"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "location"
           },
           {
             "type": "label",
@@ -306,12 +306,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.95,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "runaway train dungeon beyond the vaults todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "runaway train dungeon beyond the vaults disquiet-doom choose a random mine cart and add a reminder counter to it. it can no longer be driven and adventurers cannot get in. adventurers already on board may get out, but if they do so they suffer a two dice attack with bludgeoning bludgeoning and are knocked prone. in each assessment phase it moves once along the track in whichever direction it can move furthest from its starting point, if possible. its first move is 4 squares and subsequent moves are 7 squares. after it turns a corner or hits a track end, roll the blue die. on a blunder skull it de-rails. if the cart leaves the gaming area, adventurers on board are left for dead and anything else inside is lost. discard this card and the reminder counter if the cart de-rails or leaves play. dungeon location mines"
     },
     {
       "id": 72,
@@ -338,13 +338,13 @@
         "left": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "dungeon"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "location"
           },
           {
             "type": "label",
@@ -357,12 +357,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "g-g-g-g-ghosts! dungeon beyond the vaults todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "g-g-g-g-ghosts! dungeon beyond the vaults disquiet-doom a surge of malaclytes awakens ancient spectres. any illusions in play are removed and cannot be created while this card is in play. scatter all five illusions from the banquet table or other suitable centrepiece. these are ghosts and will activate in the npc phase. ghosts block los. characters can move through them but not stop on them. ghosts have one action (two actions if the topmost peg in the dread tracker is blue). they move towards the nearest character (ignoring characters with camouflage , moving through walls and terrain but not stopping on them) and haunt. when they haunt, roll the blue die. one or more hits will fatigue the target; a critical will also terrify them. an adventurer who is haunted but not terrified may spend a skill peg (reaction) to remove the ghost and gain 1xp. adventurers may interact with ghosts and spend a magic peg to remove them. discard this card when all ghosts are removed. dungeon location great hall"
     },
     {
       "id": 73,
@@ -384,13 +384,13 @@
         "left": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "dungeon"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "location"
           },
           {
             "type": "label",
@@ -403,12 +403,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.95,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "hall of heroes dungeon beyond the vaults todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "hall of heroes dungeon beyond the vaults disquiet-doom you have come across your adversaries’ great meeting hall and they will defend it! count ten empty spaces up the dread tracker (or as high as you can) and add a purple peg. while this card is in play, adversaries that do not have los to an enemy move towards the great hall and will wait in the centre of the room. any adversary that enters the hall becomes blessed. in each assessment phase, if there are more adversaries than adventurers in the hall, increase the dread by 1. discard this card when the purple peg is replaced. dungeon location great hall"
     },
     {
       "id": 74,
@@ -422,12 +422,12 @@
       "sections": [
         {
           "kind": "mode",
-          "label": "Disquiet-Desperation",
-          "text": "Refill all empty fonts. Add a Blessed counter to all wells, drains and other freestanding sources of water, and to the X closest sewer channels (or similar) to the edge of the board, where X is the number of parties in the game.\n\nAdventurers may interact with any object with a Blessed counter to discard the counter, restore one Health, and take a Blessed Water token."
+          "label": "DISQUIET-DESPERATION",
+          "text": "Refill all empty fonts. Add a Blessed counter to all wells, drains and other freestanding sources of water, and to the X closest sewer channels (or similar) to the edge of the board, where X is the number of parties in the game.\n\nAdventurers may Interact with any object with a Blessed counter to discard the counter, restore one Health, and take a Blessed Water token."
         },
         {
           "kind": "mode",
-          "label": "Disaster-Doom",
+          "label": "DISASTER-DOOM",
           "text": "As above. However, the Adversaries may have contaminated the water, giving it the Hazardous: Poisonous [poison] rule: When a counter is discarded/ Font interacted with, roll the blue die. If a hit is scored, the normal effects are applied. On a blunder [skull], the user is Poisoned instead. On a blank, nothing happens."
         }
       ],
@@ -435,13 +435,13 @@
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "location"
           },
           {
             "type": "label",
@@ -454,12 +454,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "nectar of the gods environment beyond the vaults todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "nectar of the gods environment beyond the vaults disquiet-desperation refill all empty fonts. add a blessed counter to all wells, drains and other freestanding sources of water, and to the x closest sewer channels (or similar) to the edge of the board, where x is the number of parties in the game. adventurers may interact with any object with a blessed counter to discard the counter, restore one health, and take a blessed water token. disaster-doom as above. however, the adversaries may have contaminated the water, giving it the hazardous: poisonous poison rule: when a counter is discarded/ font interacted with, roll the blue die. if a hit is scored, the normal effects are applied. on a blunder skull , the user is poisoned instead. on a blank, nothing happens. environment location sources of water"
     },
     {
       "id": 75,
@@ -473,12 +473,12 @@
       "sections": [
         {
           "kind": "mode",
-          "label": "Disquiet-Dismay",
+          "label": "DISQUIET-DISMAY",
           "text": "You’ve made it deep into your Adversaries’ camp and you’ve caught them by surprise. All Adversaries in play are Fatigued, and no more Adversaries will arrive this round. Replace the bottom peg in the tracker with a purple one and shuffle this card back into the deck."
         },
         {
           "kind": "mode",
-          "label": "Desperation-Doom",
+          "label": "DESPERATION-DOOM",
           "text": "Your Adversaries will defend their garrison fiercely and they have summoned reinforcements. All Adversaries in play are Blessed. Increase the Dread by 1, plus 2 more for each purple peg at the bottom of the Dread tracker (if any)."
         }
       ],
@@ -486,13 +486,13 @@
         "left": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "dungeon"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "location"
           },
           {
             "type": "label",
@@ -505,12 +505,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.95,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "infiltration dungeon beyond the vaults todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "infiltration dungeon beyond the vaults disquiet-dismay you’ve made it deep into your adversaries’ camp and you’ve caught them by surprise. all adversaries in play are fatigued, and no more adversaries will arrive this round. replace the bottom peg in the tracker with a purple one and shuffle this card back into the deck. desperation-doom your adversaries will defend their garrison fiercely and they have summoned reinforcements. all adversaries in play are blessed. increase the dread by 1, plus 2 more for each purple peg at the bottom of the dread tracker (if any). dungeon location garrison"
     },
     {
       "id": 76,
@@ -537,13 +537,13 @@
         "left": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "dungeon"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "location"
           },
           {
             "type": "label",
@@ -556,12 +556,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.95,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "shhhhh...... dungeon beyond the vaults todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "shhhhh...... dungeon beyond the vaults disquiet-distress your adversaries are not expecting a full-on assault in a place like a library, and you can take advantage of that! count four empty spaces up the dread tracker and add a purple peg. if at the moment the purple peg is replaced no adversaries have los to an enemy, you may reduce the dread by 2 and put the sentries rules into place, adding patrol points to the gaming area following the normal rules if necessary. dismay-doom as characters fight their way through the library, malacytes leach from the ancient books. any character that spends magic pegs within short range of a bookcase, book pile or similar may add a blue peg to the tracker (in addition to the normal one, if applicable) to restore up to two additional magic pegs after resolving the spell or ability. dungeon location archives"
     },
     {
       "id": 77,
@@ -583,13 +583,13 @@
         "left": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "dungeon"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "location"
           },
           {
             "type": "label",
@@ -602,12 +602,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.95,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "seize them! dungeon beyond the vaults todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "seize them! dungeon beyond the vaults disquiet-doom these prison cells are still in use! place a spare denizen prone in any cell not yet opened. they do not need a card or board as they will not activate. these denizens will be targeted by enemies as normal, and if they suffer any damage they are defeated. each may be dragged off the gaming area via a staging point to gain 1 renown, and they will count as having joined your party for the purposes of hiring. for the rest of the quest, adversaries without los to an enemy will target defeated adventurers if possible, moving towards them and dragging them to the nearest cell/cage following the normal rules. once a defeated adventurer is in a cell, the adversary will revert to its normal rules, locking the cell door as it leaves. defeated adventurers still in a cell at the end of the game (including any subsequent rescue mission) reduce their left for dead roll by 3. dungeon location bastille"
     },
     {
       "id": 78,
@@ -634,7 +634,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -644,12 +644,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "watch your step! environment beyond the vaults todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "watch your step! environment beyond the vaults disquiet-dismay falling rubble or boggy terrain makes certain areas treacherous. mark a random room with a red reminder counter and mark up to two random adjoining rooms with blue reminder counters. marked rooms are as follows: blue-reminder : rough ground 1 move 1 red-reminder : rough ground 2 move 2 yellow-reminder : rough ground 3 move 3 (see below) desperation-doom as disquiet dismay, but mark the first room with a yellow reminder and the two adjoining rooms with red reminders. environment"
     },
     {
       "id": 79,
@@ -676,11 +676,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
-          },
-          {
-            "type": "icon",
-            "name": "grave"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -690,12 +686,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.98,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "corrupted warrior veteran beyond the vaults todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "corrupted warrior veteran beyond the vaults disquiet-distress the warrior still slumbers... increase dread by 1 and shuffle this card back into the deck. then, draw and resolve another event card. dismay-doom select a random denizen. it gains two additional health pegs, two additional magic pegs, one random uncommon weapon and one random item from the token pouch. add a mini-boss insert to its board. place the miniature at a random entry point. this denizen is considered to be an adversary for all purposes. veteran"
     },
     {
       "id": 80,
@@ -709,12 +705,12 @@
       "sections": [
         {
           "kind": "mode",
-          "label": "Disquiet-Distress",
+          "label": "DISQUIET-DISTRESS",
           "text": "Increase Dread by 1. Select a random character on an upper level. If there are none, shuffle this card back into the deck and draw another.\n\nOtherwise, place a Pit in the closest possible position to that character not in contact with an Entry Point (it can be placed under other characters). The Pit is a hole to the level below. This causes noise for the purposes of Sentries.\n\nAny character on the Pit falls through, following the normal falling rules. Any character in contact with the Pit must spend a Skill peg (reaction) or fall through.\n\nPlace two Barricades under the Pit. Characters in or adjacent to those squares are pushed directly away and laid prone, and suffer an attack with 3 dice and Bludgeoning. They may spend a Skill peg (reaction) to avoid the attack."
         },
         {
           "kind": "mode",
-          "label": "Dismay-Doom",
+          "label": "DISMAY-DOOM",
           "text": "As Disquiet-Distress, but resolved twice if possible."
         }
       ],
@@ -722,7 +718,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           },
           {
             "type": "label",
@@ -730,13 +726,13 @@
           },
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "location"
           },
           {
             "type": "label",
@@ -749,12 +745,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.95,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "rotten floor veteran + environment beyond the vaults todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "rotten floor veteran + environment beyond the vaults disquiet-distress increase dread by 1. select a random character on an upper level. if there are none, shuffle this card back into the deck and draw another. otherwise, place a pit in the closest possible position to that character not in contact with an entry point (it can be placed under other characters). the pit is a hole to the level below. this causes noise for the purposes of sentries. any character on the pit falls through, following the normal falling rules. any character in contact with the pit must spend a skill peg (reaction) or fall through. place two barricades under the pit. characters in or adjacent to those squares are pushed directly away and laid prone, and suffer an attack with 3 dice and bludgeoning. they may spend a skill peg (reaction) to avoid the attack. dismay-doom as disquiet-distress, but resolved twice if possible. veteran +1 environment location multi-level gaming areas"
     },
     {
       "id": 81,
@@ -776,17 +772,21 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
+          },
+          {
+            "type": "label",
+            "text": "+"
           },
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "location"
           },
           {
             "type": "label",
@@ -799,12 +799,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.95,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "they're in the walls! veteran + environment beyond the vaults todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "they're in the walls! veteran + environment beyond the vaults disquiet-doom if the quest objectives directly involve entry points, increase dread by 2, discard this card, and draw another. if secondary entry points are already in play, increase dread by 1 and resolve adversary arrival. you will resolve it again in the adversary phase as normal. then discard this card. otherwise, determine the furthest adventurer from its staging point. roll the magic die to determine a direction and then place secondary entry points 1 and 4 short range away in that direction (or as close as possible), on a different level if possible. then, starting at this position, roll for direction again and place points 2 and 5 medium range away, again changing level if possible. repeat from this position to place points 3 and 6. for the rest of the game, roll for adversary arrival twice each round, once for each set of entry points. veteran + environment location larger and/or multi-level gaming areas"
     },
     {
       "id": 82,
@@ -826,17 +826,21 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
+          },
+          {
+            "type": "label",
+            "text": "+"
           },
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "location"
           },
           {
             "type": "label",
@@ -852,12 +856,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.98,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "the floodgates open veteran + environment beyond the vaults todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "the floodgates open veteran + environment beyond the vaults veteran environment disquiet-doom if the quest objectives directly involve entry points, increase dread by 2, discard this card, and draw another. if secondary entry points are already in play, increase dread by 1 and resolve adversary arrival. you will resolve it again in the adversary phase as normal. then discard this card. otherwise, roll the magic die for each existing entry point and place the matching secondary entry point that many spaces to its right (or as close as possible to that position). if that area has multiple levels, place the secondary entry point on a different level. for entry points on the gaming area, do not roll – place the secondary entry point in the nearest similar position available (well, staircase, or other suitable arrival position), or the same position if there are none. for the rest of the game, roll for adversary arrival twice each round, once for each set of entry points. veteran + environment location larger and/or multi-level gaming areas"
     },
     {
       "id": 83,
@@ -884,7 +888,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           },
           {
             "type": "label",
@@ -892,13 +896,13 @@
           },
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "location"
           },
           {
             "type": "label",
@@ -914,12 +918,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "the floodgates open veteran + environment beyond the vaults todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "the floodgates open veteran + environment beyond the vaults veteran environment disquiet-doom if the quest objectives directly involve entry points, increase dread by 2, discard this card, and draw another. if secondary entry points are already in play, increase dread by 1 and resolve adversary arrival. you will resolve it again in the adversary phase as normal. then discard this card. otherwise, roll the magic die for each existing entry point and place the matching secondary entry point that many spaces to its right (or as close as possible to that position). if that area has multiple levels, place the secondary entry point on a different level. for entry points on the gaming area, do not roll - place the secondary entry point in the nearest similar position available (well, staircase, or other suitable arrival position), or the same position if there are none. for the rest of the game, roll for adversary arrival twice each round, once for each set of entry points. veteran + environment location larger and/or multi-level gaming areas"
     }
   ]
 }

--- a/data/cards/extraction-report.json
+++ b/data/cards/extraction-report.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-04-12T17:07:14.527Z",
-  "processedCards": 127,
+  "generatedAt": "2026-05-15T08:50:57.110Z",
+  "processedCards": 142,
   "usedOcr": false,
   "cards": [
     {
@@ -8,14 +8,14 @@
       "game": "Base Game",
       "card": "Renewed Vigour",
       "sourceImage": "Renewed_Vigour.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -76,14 +76,14 @@
       "game": "Base Game",
       "card": "Life Drain",
       "sourceImage": "Life_Drain.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "grave"
+            "name": "revenant"
           }
         ],
         "right": []
@@ -144,14 +144,14 @@
       "game": "Base Game",
       "card": "Balefire",
       "sourceImage": "Balefire.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "revenant"
           }
         ],
         "right": []
@@ -212,14 +212,14 @@
       "game": "Base Game",
       "card": "Respite",
       "sourceImage": "Respite.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "novice"
           }
         ],
         "right": []
@@ -280,14 +280,14 @@
       "game": "Base Game",
       "card": "Snap",
       "sourceImage": "Snap.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -348,14 +348,14 @@
       "game": "Base Game",
       "card": "Malacytic Fluctuations",
       "sourceImage": "Malacytic_Fluctuations.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -416,14 +416,14 @@
       "game": "Base Game",
       "card": "Trap! Arrow",
       "sourceImage": "Trap_Arrow.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -484,14 +484,14 @@
       "game": "Base Game",
       "card": "Fiery Touch",
       "sourceImage": "Fiery_Touch.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "grave"
+            "name": "revenant"
           }
         ],
         "right": []
@@ -552,14 +552,14 @@
       "game": "Base Game",
       "card": "Feeling Lucky",
       "sourceImage": "Feeling_Lucky.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "novice"
           }
         ],
         "right": []
@@ -620,14 +620,14 @@
       "game": "Base Game",
       "card": "Alarm!",
       "sourceImage": "Alarm.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -688,14 +688,14 @@
       "game": "Base Game",
       "card": "Chilling Aura",
       "sourceImage": "Chilling_Aura.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "revenant"
           }
         ],
         "right": []
@@ -756,14 +756,14 @@
       "game": "Base Game",
       "card": "Reanimation",
       "sourceImage": "Reanimation.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "grave"
+            "name": "revenant"
           }
         ],
         "right": []
@@ -824,14 +824,14 @@
       "game": "Base Game",
       "card": "Get That One!",
       "sourceImage": "Get_That_One.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "revenant"
           }
         ],
         "right": []
@@ -892,14 +892,14 @@
       "game": "Base Game",
       "card": "Deathly Fusion",
       "sourceImage": "Deathly_Fusion.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "grave"
+            "name": "revenant"
           }
         ],
         "right": []
@@ -960,14 +960,14 @@
       "game": "Base Game",
       "card": "They're Below Us!",
       "sourceImage": "Theyre_Below_Us.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "grave"
+            "name": "revenant"
           }
         ],
         "right": []
@@ -1028,18 +1028,14 @@
       "game": "Base Game",
       "card": "Unnatural Lifeforce",
       "sourceImage": "Unnatural_Lifeforce.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "creature"
-          },
-          {
-            "type": "icon",
-            "name": "arrow-up"
+            "name": "malagaunt"
           }
         ],
         "right": []
@@ -1100,18 +1096,14 @@
       "game": "Base Game",
       "card": "Death Draws In",
       "sourceImage": "Death_Draws_In.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "otherworldly"
-          },
-          {
-            "type": "icon",
-            "name": "arrow-up"
+            "name": "malagaunt"
           }
         ],
         "right": []
@@ -1172,14 +1164,14 @@
       "game": "Base Game",
       "card": "Gleaming Trinket",
       "sourceImage": "Gleaming_Trinket.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -1240,14 +1232,14 @@
       "game": "Base Game",
       "card": "Tremors",
       "sourceImage": "Tremors.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -1308,14 +1300,14 @@
       "game": "Base Game",
       "card": "Spooked",
       "sourceImage": "Spooked.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -1376,14 +1368,14 @@
       "game": "Base Game",
       "card": "As One Door Closes...",
       "sourceImage": "As_One_Door_Closes.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -1444,14 +1436,14 @@
       "game": "Base Game",
       "card": "Trap! Snare",
       "sourceImage": "Trap_Snare.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -1512,14 +1504,14 @@
       "game": "Base Game",
       "card": "They're Everywhere",
       "sourceImage": "Theyre_Everywhere.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -1580,7 +1572,7 @@
       "game": "Base Game",
       "card": "Lost Traveller",
       "sourceImage": "Lost_Traveller.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
@@ -1648,7 +1640,7 @@
       "game": "Base Game",
       "card": "Lost Traveller",
       "sourceImage": "Lost_Traveller.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
@@ -1716,8 +1708,8 @@
       "game": "Base Game",
       "card": "Opportunist",
       "sourceImage": "Opportunist.png",
-      "status": "auto",
-      "confidence": 0.95,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
@@ -1784,7 +1776,7 @@
       "game": "Base Game",
       "card": "Opportunist",
       "sourceImage": "Opportunist.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
@@ -1852,7 +1844,7 @@
       "game": "Base Game",
       "card": "On The Hunt",
       "sourceImage": "On_The_Hunt.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
@@ -1920,7 +1912,7 @@
       "game": "Base Game",
       "card": "Out For Blood",
       "sourceImage": "Out_For_Blood.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
@@ -1988,20 +1980,20 @@
       "game": "Base Game",
       "card": "Cankers",
       "sourceImage": "Cankers.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "malacytic-conduit"
+            "name": "otherworldly"
           }
         ]
       },
@@ -2061,14 +2053,14 @@
       "game": "Base Game",
       "card": "Troglodyte",
       "sourceImage": "Troglodyte.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": []
@@ -2129,14 +2121,14 @@
       "game": "Base Game",
       "card": "Drakon",
       "sourceImage": "Drakon.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": []
@@ -2197,14 +2189,14 @@
       "game": "Base Game",
       "card": "Trap! Net",
       "sourceImage": "Trap_Net.png",
-      "status": "auto",
-      "confidence": 0.95,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -2265,14 +2257,14 @@
       "game": "Base Game",
       "card": "Trap! Pit",
       "sourceImage": "Trap_Pit.png",
-      "status": "auto",
-      "confidence": 0.95,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -2333,14 +2325,14 @@
       "game": "Base Game",
       "card": "Trap! Swinging Blade",
       "sourceImage": "Trap_Swinging_Blade.png",
-      "status": "auto",
-      "confidence": 0.95,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "wall"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -2401,14 +2393,14 @@
       "game": "Base Game",
       "card": "Fading Light",
       "sourceImage": "Fading_Light.png",
-      "status": "auto",
-      "confidence": 0.95,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -2469,14 +2461,14 @@
       "game": "Base Game",
       "card": "Collapse!",
       "sourceImage": "Collapse.png",
-      "status": "auto",
-      "confidence": 0.95,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -2537,14 +2529,14 @@
       "game": "Base Game",
       "card": "Dormant Lifeforce",
       "sourceImage": "Dormant_Lifeforce.png",
-      "status": "auto",
-      "confidence": 0.95,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "grave"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -2605,14 +2597,14 @@
       "game": "Base Game",
       "card": "Drip, Drip, Drip",
       "sourceImage": "Drip_Drip_Drip.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -2673,14 +2665,14 @@
       "game": "Base Game",
       "card": "Premonition",
       "sourceImage": "Premonition.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "novice"
           }
         ],
         "right": []
@@ -2741,14 +2733,14 @@
       "game": "Base Game",
       "card": "Teamwork",
       "sourceImage": "Teamwork.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "novice"
           }
         ],
         "right": []
@@ -2809,14 +2801,14 @@
       "game": "Base Game",
       "card": "Respite",
       "sourceImage": "Respite.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "novice"
           }
         ],
         "right": []
@@ -2877,14 +2869,14 @@
       "game": "Base Game",
       "card": "Blaze of Glory",
       "sourceImage": "Blaze_of_Glory.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "novice"
           }
         ],
         "right": []
@@ -2945,14 +2937,14 @@
       "game": "Base Game",
       "card": "Spurred On",
       "sourceImage": "Spurred_On.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "novice"
           }
         ],
         "right": []
@@ -3013,14 +3005,14 @@
       "game": "Base Game",
       "card": "Malacytic Surge",
       "sourceImage": "Malacytic_Surge.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "novice"
           }
         ],
         "right": []
@@ -3081,18 +3073,14 @@
       "game": "Base Game",
       "card": "Dangerous Ground",
       "sourceImage": "Dangerous_Ground.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
-          },
-          {
-            "type": "icon",
-            "name": "larger-area"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -3153,18 +3141,14 @@
       "game": "Base Game",
       "card": "Malacytic Exhaustion",
       "sourceImage": "Malacytic_Exhaustion.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
-          },
-          {
-            "type": "icon",
-            "name": "entry-point"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -3225,14 +3209,14 @@
       "game": "Base Game",
       "card": "Unexpected Assault",
       "sourceImage": "Unexpected_Assault.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -3293,18 +3277,14 @@
       "game": "Base Game",
       "card": "One Thing After Another",
       "sourceImage": "One_Thing_After_Another.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
-          },
-          {
-            "type": "icon",
-            "name": "entry-point"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -3365,14 +3345,14 @@
       "game": "Base Game",
       "card": "Fresh Graves",
       "sourceImage": "Fresh_Graves.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "grave"
+            "name": "revenant"
           },
           {
             "type": "label",
@@ -3380,7 +3360,7 @@
           },
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -3437,11 +3417,336 @@
       }
     },
     {
+      "id": 128,
+      "game": "Base Game",
+      "card": "Careless Swing",
+      "sourceImage": "Careless_Swing.png",
+      "status": "verified",
+      "confidence": 1,
+      "issues": [],
+      "footer": {
+        "left": [
+          {
+            "type": "icon",
+            "name": "veteran"
+          }
+        ],
+        "right": []
+      },
+      "regions": null
+    },
+    {
+      "id": 129,
+      "game": "Base Game",
+      "card": "Deadly Accuracy",
+      "sourceImage": "Deadly_Accuracy.png",
+      "status": "verified",
+      "confidence": 1,
+      "issues": [],
+      "footer": {
+        "left": [
+          {
+            "type": "icon",
+            "name": "veteran"
+          }
+        ],
+        "right": []
+      },
+      "regions": null
+    },
+    {
+      "id": 130,
+      "game": "Base Game",
+      "card": "Trap! Fireball",
+      "sourceImage": "Trap_Fireball.png",
+      "status": "verified",
+      "confidence": 1,
+      "issues": [],
+      "footer": {
+        "left": [
+          {
+            "type": "icon",
+            "name": "veteran"
+          },
+          {
+            "type": "label",
+            "text": "+"
+          },
+          {
+            "type": "icon",
+            "name": "dungeon"
+          }
+        ],
+        "right": []
+      },
+      "regions": null
+    },
+    {
+      "id": 131,
+      "game": "Base Game",
+      "card": "Wave of Exhaustion",
+      "sourceImage": "Wave_of_Exhaustion.png",
+      "status": "verified",
+      "confidence": 1,
+      "issues": [],
+      "footer": {
+        "left": [
+          {
+            "type": "icon",
+            "name": "veteran"
+          }
+        ],
+        "right": []
+      },
+      "regions": null
+    },
+    {
+      "id": 132,
+      "game": "Base Game",
+      "card": "Trap! Poison Gas",
+      "sourceImage": "Trap_Poison_Gas.png",
+      "status": "verified",
+      "confidence": 1,
+      "issues": [],
+      "footer": {
+        "left": [
+          {
+            "type": "icon",
+            "name": "veteran"
+          },
+          {
+            "type": "label",
+            "text": "+"
+          },
+          {
+            "type": "icon",
+            "name": "dungeon"
+          }
+        ],
+        "right": []
+      },
+      "regions": null
+    },
+    {
+      "id": 133,
+      "game": "Base Game",
+      "card": "Sudden Rot",
+      "sourceImage": "Sudden_Rot.png",
+      "status": "verified",
+      "confidence": 1,
+      "issues": [],
+      "footer": {
+        "left": [
+          {
+            "type": "icon",
+            "name": "veteran"
+          }
+        ],
+        "right": []
+      },
+      "regions": null
+    },
+    {
+      "id": 134,
+      "game": "Base Game",
+      "card": "Malacytic Vigour",
+      "sourceImage": "Malacytic_Vigour.png",
+      "status": "verified",
+      "confidence": 1,
+      "issues": [],
+      "footer": {
+        "left": [
+          {
+            "type": "icon",
+            "name": "veteran"
+          }
+        ],
+        "right": []
+      },
+      "regions": null
+    },
+    {
+      "id": 135,
+      "game": "Base Game",
+      "card": "Trap! Deadfall",
+      "sourceImage": "Trap_Deadfall.png",
+      "status": "verified",
+      "confidence": 1,
+      "issues": [],
+      "footer": {
+        "left": [
+          {
+            "type": "icon",
+            "name": "veteran"
+          },
+          {
+            "type": "label",
+            "text": "+"
+          },
+          {
+            "type": "icon",
+            "name": "dungeon"
+          }
+        ],
+        "right": []
+      },
+      "regions": null
+    },
+    {
+      "id": 136,
+      "game": "Base Game",
+      "card": "Crack!",
+      "sourceImage": "Crack.png",
+      "status": "verified",
+      "confidence": 1,
+      "issues": [],
+      "footer": {
+        "left": [
+          {
+            "type": "icon",
+            "name": "veteran"
+          }
+        ],
+        "right": []
+      },
+      "regions": null
+    },
+    {
+      "id": 137,
+      "game": "Base Game",
+      "card": "Get Them Off Me!",
+      "sourceImage": "Get_Them_Off_Me.png",
+      "status": "verified",
+      "confidence": 1,
+      "issues": [],
+      "footer": {
+        "left": [
+          {
+            "type": "icon",
+            "name": "veteran"
+          }
+        ],
+        "right": []
+      },
+      "regions": null
+    },
+    {
+      "id": 138,
+      "game": "Base Game",
+      "card": "Where Did I Put That?",
+      "sourceImage": "Where_Did_I_Put_That.png",
+      "status": "verified",
+      "confidence": 1,
+      "issues": [],
+      "footer": {
+        "left": [
+          {
+            "type": "icon",
+            "name": "veteran"
+          }
+        ],
+        "right": []
+      },
+      "regions": null
+    },
+    {
+      "id": 139,
+      "game": "Base Game",
+      "card": "Not Again?",
+      "sourceImage": "Not_Again.png",
+      "status": "verified",
+      "confidence": 1,
+      "issues": [],
+      "footer": {
+        "left": [
+          {
+            "type": "icon",
+            "name": "veteran"
+          }
+        ],
+        "right": []
+      },
+      "regions": null
+    },
+    {
+      "id": 140,
+      "game": "Base Game",
+      "card": "Trap! Acid Mist",
+      "sourceImage": "Trap_Acid_Mist.png",
+      "status": "verified",
+      "confidence": 1,
+      "issues": [],
+      "footer": {
+        "left": [
+          {
+            "type": "icon",
+            "name": "veteran"
+          }
+        ],
+        "right": []
+      },
+      "regions": null
+    },
+    {
+      "id": 141,
+      "game": "Base Game",
+      "card": "Trap! Wall of Fire",
+      "sourceImage": "Trap_Wall_of_Fire.png",
+      "status": "verified",
+      "confidence": 1,
+      "issues": [],
+      "footer": {
+        "left": [
+          {
+            "type": "icon",
+            "name": "veteran"
+          },
+          {
+            "type": "label",
+            "text": "+"
+          },
+          {
+            "type": "icon",
+            "name": "dungeon"
+          }
+        ],
+        "right": []
+      },
+      "regions": null
+    },
+    {
+      "id": 142,
+      "game": "Base Game",
+      "card": "Trap! Caltrops",
+      "sourceImage": "Trap_Caltrops.png",
+      "status": "verified",
+      "confidence": 1,
+      "issues": [],
+      "footer": {
+        "left": [
+          {
+            "type": "icon",
+            "name": "veteran"
+          },
+          {
+            "type": "label",
+            "text": "+"
+          },
+          {
+            "type": "icon",
+            "name": "dungeon"
+          }
+        ],
+        "right": []
+      },
+      "regions": null
+    },
+    {
       "id": 51,
       "game": "Of Ale And Adventure",
       "card": "Questgiver",
       "sourceImage": "Questgiver.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
@@ -3509,7 +3814,7 @@
       "game": "Of Ale And Adventure",
       "card": "Questgiver",
       "sourceImage": "Questgiver.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
@@ -3577,7 +3882,7 @@
       "game": "Of Ale And Adventure",
       "card": "Stand And Deliver!",
       "sourceImage": "Stand_And_Deliver.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
@@ -3645,8 +3950,8 @@
       "game": "Of Ale And Adventure",
       "card": "Bounty!",
       "sourceImage": "Bounty.png",
-      "status": "auto",
-      "confidence": 0.95,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
@@ -3713,8 +4018,8 @@
       "game": "Of Ale And Adventure",
       "card": "Nomadic Trader",
       "sourceImage": "Nomadic_Trader.png",
-      "status": "auto",
-      "confidence": 0.95,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
@@ -3781,7 +4086,7 @@
       "game": "Of Ale And Adventure",
       "card": "Excursionist",
       "sourceImage": "Excursionist.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
@@ -3849,7 +4154,7 @@
       "game": "Of Ale And Adventure",
       "card": "Panhandler",
       "sourceImage": "Panhandler.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
@@ -3917,7 +4222,7 @@
       "game": "Of Ale And Adventure",
       "card": "Wanderer",
       "sourceImage": "Wanderer.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
@@ -3985,14 +4290,14 @@
       "game": "Of Ale And Adventure",
       "card": "Rumours",
       "sourceImage": "Rumours.png",
-      "status": "auto",
-      "confidence": 0.95,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -4053,14 +4358,14 @@
       "game": "Of Ale And Adventure",
       "card": "Escape Route",
       "sourceImage": "Escape_Route.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "novice"
           }
         ],
         "right": []
@@ -4121,14 +4426,14 @@
       "game": "Of Ale And Adventure",
       "card": "It's A Trap!",
       "sourceImage": "Its_A_Trap.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "novice"
           }
         ],
         "right": []
@@ -4189,14 +4494,14 @@
       "game": "Of Ale And Adventure",
       "card": "Outta My Way!",
       "sourceImage": "Outta_My_Way.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "novice"
           }
         ],
         "right": []
@@ -4257,14 +4562,14 @@
       "game": "Of Ale And Adventure",
       "card": "Stroke Of Fortune",
       "sourceImage": "Stroke_Of_Fortune.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "novice"
           }
         ],
         "right": []
@@ -4325,18 +4630,22 @@
       "game": "Of Ale And Adventure",
       "card": "Lights Out",
       "sourceImage": "Lights_Out.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
+          },
+          {
+            "type": "label",
+            "text": "+"
           },
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -4397,18 +4706,14 @@
       "game": "Of Ale And Adventure",
       "card": "Paradigm Shift",
       "sourceImage": "Paradigm_Shift.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
-          },
-          {
-            "type": "icon",
-            "name": "grave"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -4469,20 +4774,20 @@
       "game": "Beyond The Vaults",
       "card": "Tsewer-Nami",
       "sourceImage": "Tsewer_Nami.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "location"
           },
           {
             "type": "label",
@@ -4546,20 +4851,20 @@
       "game": "Beyond The Vaults",
       "card": "Toxic Waste",
       "sourceImage": "Toxic_Waste.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "location"
           },
           {
             "type": "label",
@@ -4623,20 +4928,20 @@
       "game": "Beyond The Vaults",
       "card": "Spitting Fire",
       "sourceImage": "Spitting_Fire.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "location"
           },
           {
             "type": "label",
@@ -4700,20 +5005,20 @@
       "game": "Beyond The Vaults",
       "card": "Cave-In!",
       "sourceImage": "Cave_In.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "dungeon"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "location"
           },
           {
             "type": "label",
@@ -4777,14 +5082,14 @@
       "game": "Beyond The Vaults",
       "card": "Heigh-Ho, Heigh-Ho!",
       "sourceImage": "Heigh_Ho_Heigh_Ho.png",
-      "status": "auto",
-      "confidence": 0.95,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "dungeon"
           },
           {
             "type": "label",
@@ -4798,7 +5103,7 @@
         "right": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "location"
           },
           {
             "type": "label",
@@ -4862,20 +5167,20 @@
       "game": "Beyond The Vaults",
       "card": "Runaway Train",
       "sourceImage": "Runaway_Train.png",
-      "status": "auto",
-      "confidence": 0.95,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "dungeon"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "location"
           },
           {
             "type": "label",
@@ -4939,20 +5244,20 @@
       "game": "Beyond The Vaults",
       "card": "G-G-G-G-Ghosts!",
       "sourceImage": "G-G-G-G-Ghosts.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "dungeon"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "location"
           },
           {
             "type": "label",
@@ -5016,20 +5321,20 @@
       "game": "Beyond The Vaults",
       "card": "Hall of Heroes",
       "sourceImage": "Hall_of_Heroes.png",
-      "status": "auto",
-      "confidence": 0.95,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "dungeon"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "location"
           },
           {
             "type": "label",
@@ -5093,20 +5398,20 @@
       "game": "Beyond The Vaults",
       "card": "Nectar Of The Gods",
       "sourceImage": "Nectar_Of_The_Gods.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "location"
           },
           {
             "type": "label",
@@ -5170,20 +5475,20 @@
       "game": "Beyond The Vaults",
       "card": "Infiltration",
       "sourceImage": "Infiltration.png",
-      "status": "auto",
-      "confidence": 0.95,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "dungeon"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "location"
           },
           {
             "type": "label",
@@ -5247,20 +5552,20 @@
       "game": "Beyond The Vaults",
       "card": "Shhhhh......",
       "sourceImage": "Shhhhh.png",
-      "status": "auto",
-      "confidence": 0.95,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "dungeon"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "location"
           },
           {
             "type": "label",
@@ -5324,20 +5629,20 @@
       "game": "Beyond The Vaults",
       "card": "Seize Them!",
       "sourceImage": "Seize_Them.png",
-      "status": "auto",
-      "confidence": 0.95,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "dungeon"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "location"
           },
           {
             "type": "label",
@@ -5401,14 +5706,14 @@
       "game": "Beyond The Vaults",
       "card": "Watch Your Step!",
       "sourceImage": "Watch_Your_Step.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -5469,18 +5774,14 @@
       "game": "Beyond The Vaults",
       "card": "Corrupted Warrior",
       "sourceImage": "Corrupted_Warrior.png",
-      "status": "auto",
-      "confidence": 0.98,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
-          },
-          {
-            "type": "icon",
-            "name": "grave"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -5541,14 +5842,14 @@
       "game": "Beyond The Vaults",
       "card": "Rotten Floor",
       "sourceImage": "Rotten_Floor.png",
-      "status": "auto",
-      "confidence": 0.95,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           },
           {
             "type": "label",
@@ -5556,13 +5857,13 @@
           },
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "location"
           },
           {
             "type": "label",
@@ -5626,24 +5927,28 @@
       "game": "Beyond The Vaults",
       "card": "They're In The Walls!",
       "sourceImage": "Theyre_In_The_Walls.png",
-      "status": "auto",
-      "confidence": 0.95,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
+          },
+          {
+            "type": "label",
+            "text": "+"
           },
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "location"
           },
           {
             "type": "label",
@@ -5707,24 +6012,28 @@
       "game": "Beyond The Vaults",
       "card": "The Floodgates Open",
       "sourceImage": "The_Floodgates_Open.png",
-      "status": "auto",
-      "confidence": 0.98,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
+          },
+          {
+            "type": "label",
+            "text": "+"
           },
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "location"
           },
           {
             "type": "label",
@@ -5788,14 +6097,14 @@
       "game": "Beyond The Vaults",
       "card": "The Floodgates Open",
       "sourceImage": "The_Floodgates_Open.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           },
           {
             "type": "label",
@@ -5803,13 +6112,13 @@
           },
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "location"
           },
           {
             "type": "label",
@@ -5873,14 +6182,14 @@
       "game": "Revenant Retribution",
       "card": "High Alert",
       "sourceImage": "High_Alert.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "revenant"
           },
           {
             "type": "label",
@@ -5888,7 +6197,7 @@
           },
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -5949,14 +6258,14 @@
       "game": "Revenant Retribution",
       "card": "Fortune Favours The Grave",
       "sourceImage": "Fortune_Favours_The_Grave.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "grave"
+            "name": "revenant"
           },
           {
             "type": "label",
@@ -5964,7 +6273,7 @@
           },
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -6025,14 +6334,14 @@
       "game": "Revenant Retribution",
       "card": "Lurching Forth",
       "sourceImage": "Lurching_Forth.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "revenant"
           },
           {
             "type": "label",
@@ -6040,7 +6349,7 @@
           },
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -6101,14 +6410,14 @@
       "game": "Revenant Retribution",
       "card": "Dead-Jà Vu",
       "sourceImage": "Dead_Ja_Vu.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "grave"
+            "name": "revenant"
           },
           {
             "type": "label",
@@ -6116,7 +6425,7 @@
           },
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -6177,14 +6486,14 @@
       "game": "Revenant Retribution",
       "card": "Deathly Avatar",
       "sourceImage": "Deathly_Avatar.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "otherworldly"
+            "name": "revenant"
           },
           {
             "type": "label",
@@ -6192,7 +6501,7 @@
           },
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -6253,14 +6562,14 @@
       "game": "Beasts Of Environ",
       "card": "Split-Tail Rats",
       "sourceImage": "Split_Tail_Rats.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": []
@@ -6321,20 +6630,20 @@
       "game": "Beasts Of Environ",
       "card": "Alary",
       "sourceImage": "Alary.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "otherworldly"
           }
         ]
       },
@@ -6394,14 +6703,14 @@
       "game": "Beasts Of Environ",
       "card": "Great Bear",
       "sourceImage": "Great_Bear.png",
-      "status": "auto",
-      "confidence": 0.95,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": []
@@ -6462,14 +6771,14 @@
       "game": "Beasts Of Environ",
       "card": "Bloodwyrm",
       "sourceImage": "Bloodwyrm.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": []
@@ -6530,20 +6839,20 @@
       "game": "Beasts Of Environ",
       "card": "Skin Shifter",
       "sourceImage": "Skin_Shifter.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "malacytic-conduit"
+            "name": "otherworldly"
           }
         ]
       },
@@ -6603,14 +6912,14 @@
       "game": "Beasts Of Environ",
       "card": "Crag Troll",
       "sourceImage": "Crag_Troll.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": []
@@ -6671,14 +6980,14 @@
       "game": "Beasts Of Environ",
       "card": "It's Alive",
       "sourceImage": "Its_Alive.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -6739,14 +7048,14 @@
       "game": "Beasts Of Environ",
       "card": "Home Invasion",
       "sourceImage": "Home_Invasion.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -6807,7 +7116,7 @@
       "game": "Beasts Of Environ",
       "card": "Unmasked!",
       "sourceImage": "Unmasked.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
@@ -6875,24 +7184,24 @@
       "game": "Oblivion's Maw",
       "card": "Eldritch Tentacle",
       "sourceImage": "Eldritch_Tentacle.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "malacytic-conduit"
+            "name": "corrupter"
           },
           {
             "type": "icon",
-            "name": "otherworldly"
+            "name": "wandering-beast"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "otherworldly"
           }
         ]
       },
@@ -6952,18 +7261,18 @@
       "game": "Oblivion's Maw",
       "card": "Eldritch Tentacle",
       "sourceImage": "Eldritch_Tentacle.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "malacytic-conduit"
+            "name": "corrupter"
           },
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": [
@@ -7029,18 +7338,18 @@
       "game": "Oblivion's Maw",
       "card": "Eldritch Tentacle",
       "sourceImage": "Eldritch_Tentacle.png",
-      "status": "auto",
-      "confidence": 0.95,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "malacytic-conduit"
+            "name": "corrupter"
           },
           {
             "type": "icon",
-            "name": "otherworldly"
+            "name": "wandering-beast"
           }
         ],
         "right": [
@@ -7106,14 +7415,14 @@
       "game": "Oblivion's Maw",
       "card": "It's Behind You!",
       "sourceImage": "Its_Behind_You.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "malacytic-conduit"
+            "name": "corrupter"
           }
         ],
         "right": []
@@ -7174,14 +7483,14 @@
       "game": "Oblivion's Maw",
       "card": "Corrupt Talisman",
       "sourceImage": "Corrupt_Talisman.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "malacytic-conduit"
+            "name": "corrupter"
           }
         ],
         "right": []
@@ -7242,14 +7551,14 @@
       "game": "Oblivion's Maw",
       "card": "Ethereal Power",
       "sourceImage": "Ethereal_Power.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -7310,14 +7619,14 @@
       "game": "Oblivion's Maw",
       "card": "Deathly Draught",
       "sourceImage": "Deathly_Draught.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -7378,14 +7687,14 @@
       "game": "Oblivion's Maw",
       "card": "Don't Look Up",
       "sourceImage": "Dont_Look_Up.png",
-      "status": "auto",
-      "confidence": 0.95,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -7446,14 +7755,14 @@
       "game": "Oblivion's Maw",
       "card": "Halls Of Veneration",
       "sourceImage": "Halls_Of_Veneration.png",
-      "status": "auto",
-      "confidence": 0.95,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -7514,14 +7823,14 @@
       "game": "Oblivion's Maw",
       "card": "Cursed Chest",
       "sourceImage": "Cursed_Chest.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": [
@@ -7587,20 +7896,20 @@
       "game": "Oblivion's Maw",
       "card": "Cursed Portal",
       "sourceImage": "Cursed_Portal.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "malacytic-conduit"
+            "name": "otherworldly"
           }
         ]
       },
@@ -7660,14 +7969,14 @@
       "game": "Oblivion's Maw",
       "card": "Cursed Vestiges",
       "sourceImage": "Cursed_Vestiges.png",
-      "status": "auto",
-      "confidence": 0.95,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": [
@@ -7733,18 +8042,22 @@
       "game": "Oblivion's Maw",
       "card": "Trap! Ancient Wards",
       "sourceImage": "Trap_Ancient_Wards.png",
-      "status": "auto",
-      "confidence": 0.95,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
+          },
+          {
+            "type": "label",
+            "text": "+"
           },
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -7805,18 +8118,22 @@
       "game": "Oblivion's Maw",
       "card": "Trap! Crushing Ceiling",
       "sourceImage": "Trap_Crushing_Ceiling.png",
-      "status": "auto",
-      "confidence": 0.95,
+      "status": "verified",
+      "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
+          },
+          {
+            "type": "label",
+            "text": "+"
           },
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -7877,14 +8194,14 @@
       "game": "Oblivion's Maw",
       "card": "Summon The Master...",
       "sourceImage": "Summon_The_Master.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -7943,22 +8260,22 @@
     {
       "id": 113,
       "game": "Forbidden Creed",
-      "card": "Maladite Golum",
+      "card": "Maladite Golem",
       "sourceImage": "Maladite_Golum.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "malacytic-conduit"
+            "name": "otherworldly"
           }
         ]
       },
@@ -8018,14 +8335,14 @@
       "game": "Forbidden Creed",
       "card": "The Cabal",
       "sourceImage": "The_Cabal.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "cabal"
           }
         ],
         "right": []
@@ -8086,14 +8403,14 @@
       "game": "Forbidden Creed",
       "card": "Debased Acolyte",
       "sourceImage": "Debased_Acolyte.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "cabal"
           }
         ],
         "right": []
@@ -8154,7 +8471,7 @@
       "game": "Forbidden Creed",
       "card": "Treacherous Terrain",
       "sourceImage": "Treacherous_Terrain.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
@@ -8222,7 +8539,7 @@
       "game": "Forbidden Creed",
       "card": "Treacherous Terrain",
       "sourceImage": "Treacherous_Terrain.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
@@ -8290,7 +8607,7 @@
       "game": "Forbidden Creed",
       "card": "Thunderstorm",
       "sourceImage": "Thunderstorm.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
@@ -8358,7 +8675,7 @@
       "game": "Forbidden Creed",
       "card": "Ambush!",
       "sourceImage": "Ambush.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
@@ -8426,7 +8743,7 @@
       "game": "Forbidden Creed",
       "card": "Chill Wind",
       "sourceImage": "Chill_Wind.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
@@ -8494,7 +8811,7 @@
       "game": "Forbidden Creed",
       "card": "Dusk To Dawn",
       "sourceImage": "Dusk_To_Dawn.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
@@ -8562,7 +8879,7 @@
       "game": "Forbidden Creed",
       "card": "Falling Rocks",
       "sourceImage": "Falling_Rocks.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
@@ -8630,7 +8947,7 @@
       "game": "Forbidden Creed",
       "card": "Howling Gale",
       "sourceImage": "Howling_Gale.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
@@ -8698,14 +9015,14 @@
       "game": "Forbidden Creed",
       "card": "Malacytic Scourge",
       "sourceImage": "Malacytic_Scourge.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -8766,14 +9083,14 @@
       "game": "Forbidden Creed",
       "card": "Purifying Aether",
       "sourceImage": "Purifying_Aether.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "novice"
           }
         ],
         "right": []
@@ -8834,14 +9151,14 @@
       "game": "Forbidden Creed",
       "card": "Touched By Darkness",
       "sourceImage": "Touched_By_Darkness.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -8902,18 +9219,14 @@
       "game": "Forbidden Creed",
       "card": "They Are Coming",
       "sourceImage": "They_Are_Coming.png",
-      "status": "auto",
+      "status": "verified",
       "confidence": 1,
       "issues": [],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
-          },
-          {
-            "type": "icon",
-            "name": "entry-point"
+            "name": "veteran"
           }
         ],
         "right": []

--- a/data/cards/forbidden-creed.json
+++ b/data/cards/forbidden-creed.json
@@ -3,8 +3,8 @@
   "cards": [
     {
       "id": 113,
-      "card": "Maladite Golum",
-      "slug": "maladite-golum",
+      "card": "Maladite Golem",
+      "slug": "maladite-golem",
       "type": "Wandering Beast",
       "game": "Forbidden Creed",
       "sourceImage": "Maladite_Golum.png",
@@ -26,13 +26,13 @@
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "malacytic-conduit"
+            "name": "otherworldly"
           }
         ]
       },
@@ -43,12 +43,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "maladite golum wandering beast forbidden creed todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "maladite golem wandering beast forbidden creed wandering beast disquiet-desperation if there are fewer than five blue pegs in the dread tracker, replace the lowest black peg with a blue peg and shuffle this card back into the deck. otherwise, place a maladite golem at a random entry point and activate it immediately. before the golem activates each turn, replace the lowest blue peg in the dread tracker with a black peg. if you cannot, the golem is defeated. this character follows normal npc activation rules considering all other characters to be enemies. however, if unengaged it will target the closest corrupted character if possible. unengaged adventurers within los and medium range of the golem may spend x magic pegs as an action to place x reminder counters on the golem. when it activates, that character may discard them to take actions with the golem up to its normal limit. any remaining actions follow its normal rules. other characters may add reminders, discarding any already there, provided x is more than the current number of counters. disaster-doom as above, but flip the maladite golem’s character board to the elite side. wandering-beast otherworldly"
     },
     {
       "id": 114,
@@ -66,7 +66,7 @@
           "text": "Resolve a Cabal spell. Then shuffle this card back into the deck."
         },
         {
-          "kind": "body",
+          "kind": "mode",
           "label": "DISMAY-DOOM",
           "text": "If the Cabal have been defeated in the current quest, discard this card.\n\nIf they are in play, resolve a Cabal spell. Then shuffle this card back into the deck.\n\nOtherwise, increase the Members track by 1, if possible. Then that many Cabal members enter play at random Entry Points (roll separately for each). Refer to the Cabal Reference card for their rules. Then shuffle this card back into the deck."
         }
@@ -75,7 +75,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "cabal"
           }
         ],
         "right": []
@@ -87,12 +87,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "the cabal cabal forbidden creed todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "the cabal cabal forbidden creed cabal disquiet-distress resolve a cabal spell. then shuffle this card back into the deck. dismay-doom if the cabal have been defeated in the current quest, discard this card. if they are in play, resolve a cabal spell. then shuffle this card back into the deck. otherwise, increase the members track by 1, if possible. then that many cabal members enter play at random entry points (roll separately for each). refer to the cabal reference card for their rules. then shuffle this card back into the deck. cabal"
     },
     {
       "id": 115,
@@ -114,7 +114,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "cabal"
           }
         ],
         "right": []
@@ -124,12 +124,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "debased acolyte cabal forbidden creed todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "debased acolyte cabal forbidden creed disquiet-doom if the cabal have been defeated in this quest, discard this card. otherwise, select a random denizen. it gains one random uncommon weapon and one random item from the token pouch. place it at a random entry point. this denizen is an acolyte of the cabal and is treated as an adversary for all purposes. resolve a cabal spell. then shuffle this card back into the deck. cabal"
     },
     {
       "id": 116,
@@ -149,56 +149,6 @@
         {
           "kind": "mode",
           "label": "DESPERATION-DOOM",
-          "text": "As Disquiet-Dismay. In addition, place a Reminder counter into the room. If a copy of this card is already in play, the chosen room must be different to the one already marked if possible, and the second copy of the card can be discarded.",
-          "threshold": 2
-        },
-        {
-          "kind": "box",
-          "label": "",
-          "text": "Marked rooms are [move:2] until the end of the game."
-        }
-      ],
-      "footer": {
-        "left": [
-          {
-            "type": "icon",
-            "name": "mountain"
-          }
-        ],
-        "right": []
-      },
-      "tags": [
-        "Mountain"
-      ],
-      "tokens": {
-        "style": "inline-bracket"
-      },
-      "extraction": {
-        "status": "auto",
-        "confidence": 1,
-        "issues": [],
-        "managedBy": "extractor"
-      },
-      "searchText": "treacherous terrain mountain forbidden creed mountain disquiet-dismay determine a random adventurer. they have stumbled on some loose scree or black ice and must spend a skill peg (reaction) or be knocked prone. all other characters in the same room roll a combat die – on a blunder they are knocked prone. desperation-doom as disquiet-dismay. in addition, place a reminder counter into the room. if a copy of this card is already in play, the chosen room must be different to the one already marked if possible, and the second copy of the card can be discarded. marked rooms are move 2 until the end of the game. mountain"
-    },
-    {
-      "id": 117,
-      "card": "Treacherous Terrain",
-      "slug": "treacherous-terrain",
-      "type": "Mountain",
-      "game": "Forbidden Creed",
-      "sourceImage": "Treacherous_Terrain.png",
-      "contents": "Treacherous_Terrain.png",
-      "renderMode": "rich",
-      "sections": [
-        {
-          "kind": "mode",
-          "label": "Disquiet-Dismay",
-          "text": "Determine a random Adventurer. They have stumbled on some loose scree or black ice and must spend a Skill peg (reaction) or be knocked prone. All other characters in the same room roll a combat die – on a blunder they are knocked prone."
-        },
-        {
-          "kind": "mode",
-          "label": "Desperation-Doom",
           "text": "As Disquiet-Dismay. In addition, place a Reminder counter into the room. If a copy of this card is already in play, the chosen room must be different to the one already marked if possible, and the second copy of the card can be discarded."
         },
         {
@@ -223,12 +173,61 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "treacherous terrain mountain forbidden creed todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "treacherous terrain mountain forbidden creed mountain disquiet-dismay determine a random adventurer. they have stumbled on some loose scree or black ice and must spend a skill peg (reaction) or be knocked prone. all other characters in the same room roll a combat die – on a blunder they are knocked prone. desperation-doom as disquiet-dismay. in addition, place a reminder counter into the room. if a copy of this card is already in play, the chosen room must be different to the one already marked if possible, and the second copy of the card can be discarded. marked rooms are move 2 until the end of the game. mountain"
+    },
+    {
+      "id": 117,
+      "card": "Treacherous Terrain",
+      "slug": "treacherous-terrain",
+      "type": "Mountain",
+      "game": "Forbidden Creed",
+      "sourceImage": "Treacherous_Terrain.png",
+      "contents": "Treacherous_Terrain.png",
+      "renderMode": "rich",
+      "sections": [
+        {
+          "kind": "mode",
+          "label": "DISQUIET-DISMAY",
+          "text": "Determine a random Adventurer. They have stumbled on some loose scree or black ice and must spend a Skill peg (reaction) or be knocked prone. All other characters in the same room roll a combat die – on a blunder they are knocked prone."
+        },
+        {
+          "kind": "mode",
+          "label": "DESPERATION-DOOM",
+          "text": "As Disquiet-Dismay. In addition, place a Reminder counter into the room. If a copy of this card is already in play, the chosen room must be different to the one already marked if possible, and the second copy of the card can be discarded."
+        },
+        {
+          "kind": "box",
+          "label": "",
+          "text": "Marked rooms are [move:2] until the end of the game."
+        }
+      ],
+      "footer": {
+        "left": [
+          {
+            "type": "icon",
+            "name": "mountain"
+          }
+        ],
+        "right": []
+      },
+      "tags": [
+        "Mountain"
+      ],
+      "tokens": {
+        "style": "inline-bracket"
+      },
+      "extraction": {
+        "status": "verified",
+        "confidence": 1,
+        "issues": [],
+        "managedBy": "human"
+      },
+      "searchText": "treacherous terrain mountain forbidden creed mountain disquiet-dismay determine a random adventurer. they have stumbled on some loose scree or black ice and must spend a skill peg (reaction) or be knocked prone. all other characters in the same room roll a combat die – on a blunder they are knocked prone. desperation-doom as disquiet-dismay. in addition, place a reminder counter into the room. if a copy of this card is already in play, the chosen room must be different to the one already marked if possible, and the second copy of the card can be discarded. marked rooms are move 2 until the end of the game. mountain"
     },
     {
       "id": 118,
@@ -267,12 +266,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "thunderstorm mountain forbidden creed todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "thunderstorm mountain forbidden creed mountain disquiet-doom increase dread by 1. the entire gaming area is move 1 unless already higher, and all squares are a source of water. los is limited to short range unless characters have hawkeye hawkeye or night sight night-sight . in the assessment phase, scatter from the centre of the gaming area and place a reminder counter. any character in or adjacent to that square is struck by lightning and suffers an attack with three dice and piercing piercing . repeat this in each subsequent assessment phase, scattering from the previous position. after resolving the lightning strike, if a 1 was rolled for the scatter, discard this card. mountain"
     },
     {
       "id": 119,
@@ -286,12 +285,12 @@
       "sections": [
         {
           "kind": "mode",
-          "label": "Disquiet-Dismay",
+          "label": "DISQUIET-DISMAY",
           "text": "In such an open location your attackers could be hiding anywhere... For each Adversary type arriving this round, instead of rolling for Entry Points, instead determine a random Adventurer. That Adversary will arrive from the square on the edge of the gaming area with the shortest route to that Adventurer. Adversaries arriving from Grave Points or any other arrival position arrive as normal. Shuffle this card back into the deck."
         },
         {
           "kind": "mode",
-          "label": "Desperation-Doom",
+          "label": "DESPERATION-DOOM",
           "text": "This round, resolve the Adversary Phase before the Adventurer Phase. Adversary arrival is resolved as detailed for Disquiet-Dismay."
         }
       ],
@@ -309,12 +308,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "ambush! mountain forbidden creed todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "ambush! mountain forbidden creed disquiet-dismay in such an open location your attackers could be hiding anywhere... for each adversary type arriving this round, instead of rolling for entry points, instead determine a random adventurer. that adversary will arrive from the square on the edge of the gaming area with the shortest route to that adventurer. adversaries arriving from grave points or any other arrival position arrive as normal. shuffle this card back into the deck. desperation-doom this round, resolve the adversary phase before the adventurer phase. adversary arrival is resolved as detailed for disquiet-dismay. mountain"
     },
     {
       "id": 120,
@@ -353,12 +352,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "chill wind mountain forbidden creed todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "chill wind mountain forbidden creed mountain disquiet-doom the wind changes and the biting cold starts to affect your adventurers. count eight spaces up the dread tracker and add a purple peg. while this card is in play, adventurers and denizens become fatigued at the end of any turn in which they did not move. if an adventurer or denizen becomes stunned they lose one health. discard this card when the purple peg is replaced. mountain"
     },
     {
       "id": 121,
@@ -397,12 +396,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "dusk to dawn mountain forbidden creed todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "dusk to dawn mountain forbidden creed mountain disquiet-desperation the sun is slowly rising/setting. the gaming area gradually changes from light to dark or vice versa. randomly determine an edge of the gaming area. as each new dread band is entered for the first time, the area within four squares of the chosen edge becomes dark/light as appropriate. move two darkness/light counters along the sides of the gaming area to mark how far the effect has reached. disaster-doom the sun breaks through/is obscured by clouds. the gaming area suddenly changes from light to dark or vice versa. randomly determine an edge of the gaming area and mark it with a darkness/light counter. the half of the gaming area closest to that edge becomes dark/light as appropriate. mountain"
     },
     {
       "id": 122,
@@ -439,12 +438,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "falling rocks mountain forbidden creed todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "falling rocks mountain forbidden creed disquiet-desperation an adventurer has put a foot wrong and rocks and rubble become loose. the adventurer closest to a wall suffers an attack with two dice, blast and bludgeoning bludgeoning . then shuffle this card back into the deck. disaster-doom there is too much movement in the area and the walls themselves are coming down! the adventurer closest to a wall suffers an attack with three dice, blast and bludgeoning bludgeoning . the wall closest to them is removed from the game and replaced with a barricade. mountain"
     },
     {
       "id": 123,
@@ -478,12 +477,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "howling gale mountain forbidden creed todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "howling gale mountain forbidden creed mountain disquiet-doom a powerful wind blasts through the area. roll the magic die to determine a direction. the number rolled is the strength of the wind. if a 1 was rolled, increase dread by 1 and shuffle this card back into the deck. otherwise, the wind affects all movable terrain pieces and all characters not in contact with a wall or immovable terrain piece. each is moved a number of squares in the direction rolled equal to the number rolled minus their size, rounding down. attacks of opportunity do not apply. any character moved three or more squares is knocked prone. any character that hits a wall or other obstacle and would still be moved further suffers an attack with two dice and bludgeoning bludgeoning . any character may spend a skill peg (reaction) to avoid these effects. mountain"
     },
     {
       "id": 124,
@@ -515,7 +514,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -525,12 +524,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "malacytic scourge environment forbidden creed todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "malacytic scourge environment forbidden creed disquiet-distress determine a random adventurer. they become cursed. then shuffle this card back into the deck. dismay-desperation determine a random adventurer. they become corrupted. the closest other character to them becomes cursed. then shuffle this card back into the deck. disaster-doom determine a random adventurer. they become corrupted. each character within short range of them becomes cursed. environment"
     },
     {
       "id": 125,
@@ -557,7 +556,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "novice"
           }
         ],
         "right": []
@@ -569,12 +568,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "purifying aether novice forbidden creed todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "purifying aether novice forbidden creed novice disquiet-distress reduce dread by 1. all characters may replace their rightmost black health peg with a green one. npcs will automatically do this. characters with no black health pegs gain a skill peg, ignoring their normal limit. then, if the ascendant is in play, all characters with no black pegs increase their tethered value by 1. dismay-doom as disquiet-distress. then, all characters may restore the rightmost crossed-out health space on their character board, if applicable. novice"
     },
     {
       "id": 126,
@@ -601,7 +600,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -613,12 +612,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "touched by darkness veteran forbidden creed todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "touched by darkness veteran forbidden creed veteran disquiet-desperation increase dread by 1. all characters must discard a magic peg or become corrupted. then shuffle this card back into the deck. disaster-doom all characters with any black health pegs that have not lost control cross out the leftmost health space on their character board. then all characters must discard two magic pegs or become corrupted. veteran"
     },
     {
       "id": 127,
@@ -632,12 +631,12 @@
       "sections": [
         {
           "kind": "mode",
-          "label": "Disquiet-Dismay",
+          "label": "DISQUIET-DISMAY",
           "text": "Increase Dread by 1.\nThen, roll the Magic Die. Count empty spaces from the bottom of the Dread Tracker equal to the number rolled and insert a purple peg. Repeat this, starting from the previous purple peg, until you have added three pegs.\nIn any round where a purple peg was replaced, resolve Adversary arrival twice. Discard this card at the end of the round when the last purple peg is replaced."
         },
         {
           "kind": "mode",
-          "label": "Desperation-Doom",
+          "label": "DESPERATION-DOOM",
           "text": "For the rest of the game, resolve Adversary arrival twice in any round where a Magic peg was added to the tracker."
         }
       ],
@@ -645,11 +644,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
-          },
-          {
-            "type": "icon",
-            "name": "entry-point"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -661,12 +656,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "they are coming veteran forbidden creed todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "they are coming veteran forbidden creed veteran disquiet-dismay increase dread by 1. then, roll the magic die. count empty spaces from the bottom of the dread tracker equal to the number rolled and insert a purple peg. repeat this, starting from the previous purple peg, until you have added three pegs. in any round where a purple peg was replaced, resolve adversary arrival twice. discard this card at the end of the round when the last purple peg is replaced. desperation-doom for the rest of the game, resolve adversary arrival twice in any round where a magic peg was added to the tracker. veteran"
     }
   ]
 }

--- a/data/cards/icons.json
+++ b/data/cards/icons.json
@@ -1,224 +1,492 @@
 {
   "fire": {
-    "aliases": ["flame", "burn"],
+    "aliases": [
+      "flame",
+      "burn"
+    ],
     "kind": "inline",
     "asset": "assets/icons/fire.svg",
     "notes": "Inline fire or burning damage icon."
   },
   "move": {
-    "aliases": ["movement"],
+    "aliases": [
+      "movement"
+    ],
     "kind": "inline",
     "asset": "assets/icons/move.svg",
     "notes": "Movement or move action icon."
   },
   "enemy": {
-    "aliases": ["adversary", "monster"],
+    "aliases": [
+      "adversary",
+      "monster"
+    ],
     "kind": "inline",
     "asset": "assets/icons/enemy.svg",
     "notes": "Enemy or adversary reference icon."
   },
   "armour": {
-    "aliases": ["shield", "defense", "physical-armour"],
+    "aliases": [
+      "shield",
+      "defense",
+      "physical-armour"
+    ],
     "kind": "inline",
     "asset": "assets/icons/armour.png",
     "notes": "Official Battle Systems armour icon from the Maladum item database."
   },
   "bludgeoning": {
-    "aliases": ["mace", "hammer", "impact"],
+    "aliases": [
+      "mace",
+      "hammer",
+      "impact"
+    ],
     "kind": "inline",
     "asset": "assets/icons/bludgeoning.png",
     "notes": "Official Battle Systems bludgeoning icon."
   },
   "camouflage": {
-    "aliases": ["stealth", "hidden"],
+    "aliases": [
+      "stealth",
+      "hidden"
+    ],
     "kind": "inline",
     "asset": "assets/icons/camouflage.png",
     "notes": "Official Battle Systems camouflage icon."
   },
   "creature": {
-    "aliases": ["beast", "monster-head"],
+    "aliases": [
+      "beast",
+      "monster-head"
+    ],
     "kind": "inline",
     "asset": "assets/icons/creature.png",
     "notes": "Official Battle Systems creature icon."
   },
   "denizen": {
-    "aliases": ["silhouette", "npc", "villager"],
+    "aliases": [
+      "silhouette",
+      "npc",
+      "villager"
+    ],
     "kind": "inline",
     "asset": "assets/icons/denizen.png",
     "notes": "Local crop of the circular denizen/silhouette icon from Unmasked!."
   },
   "entangling": {
-    "aliases": ["snare", "net"],
+    "aliases": [
+      "snare",
+      "net"
+    ],
     "kind": "inline",
     "asset": "assets/icons/entangling.png",
     "notes": "Official Battle Systems entangling icon."
   },
   "skull": {
-    "aliases": ["death"],
+    "aliases": [
+      "death"
+    ],
     "kind": "inline",
     "asset": "assets/icons/skull.svg",
     "notes": "Death or skull symbol."
   },
   "hawkeye": {
-    "aliases": ["eagle-eye", "ignore-cover"],
+    "aliases": [
+      "eagle-eye",
+      "ignore-cover"
+    ],
     "kind": "inline",
     "asset": "assets/icons/hawkeye.png",
     "notes": "Official Battle Systems hawkeye icon."
   },
   "health": {
-    "aliases": ["restore-health", "heart"],
+    "aliases": [
+      "restore-health",
+      "heart"
+    ],
     "kind": "inline",
     "asset": "assets/icons/health.png",
     "notes": "Health icon derived from the official Battle Systems restore health icon."
   },
   "malacytic-conduit": {
-    "aliases": ["corrupter", "malacytic_conduit"],
+    "aliases": [
+      "malacytic_conduit"
+    ],
     "kind": "inline",
     "asset": "assets/icons/malacytic-conduit.png",
     "notes": "Official Battle Systems Malacytic Conduit icon."
   },
+  "corrupter": {
+    "aliases": [
+      "corrupter-card",
+      "corrupter-icon"
+    ],
+    "kind": "inline",
+    "asset": "logos/Corrupter.jpg",
+    "notes": "Green Corrupter card-type emblem used on Corrupter event cards."
+  },
   "melee": {
-    "aliases": ["attack", "combat", "unarmed-combat"],
+    "aliases": [
+      "attack",
+      "combat",
+      "unarmed-combat"
+    ],
     "kind": "inline",
     "asset": "assets/icons/melee.png",
     "notes": "Official Battle Systems melee icon."
   },
   "night-sight": {
-    "aliases": ["night_sight", "darkvision"],
+    "aliases": [
+      "night_sight",
+      "darkvision"
+    ],
     "kind": "inline",
     "asset": "assets/icons/night-sight.png",
     "notes": "Official Battle Systems Night Sight icon."
   },
   "no-defence": {
-    "aliases": ["no-defense", "ignore-armour", "ignore-armor"],
+    "aliases": [
+      "no-defense",
+      "ignore-armour",
+      "ignore-armor"
+    ],
     "kind": "inline",
     "asset": "assets/icons/no-defence.png",
     "notes": "Local crop of the shield-with-slash icon from Tsewer-Nami."
   },
   "otherworldly": {
-    "aliases": ["eldritch", "voidborn"],
+    "aliases": [
+      "eldritch",
+      "voidborn"
+    ],
     "kind": "inline",
     "asset": "assets/icons/otherworldly.png",
     "notes": "Official Battle Systems Otherworldly icon."
   },
   "piercing": {
-    "aliases": ["pierce", "armour-break"],
+    "aliases": [
+      "pierce",
+      "armour-break"
+    ],
     "kind": "inline",
     "asset": "assets/icons/piercing.png",
     "notes": "Official Battle Systems piercing icon."
   },
   "plunderer": {
-    "aliases": ["loot", "loot-bag", "thief"],
+    "aliases": [
+      "loot",
+      "loot-bag",
+      "thief"
+    ],
     "kind": "inline",
     "asset": "assets/icons/plunderer.png",
     "notes": "Official Battle Systems plunderer icon."
   },
   "poison": {
-    "aliases": ["poisonous", "venom"],
+    "aliases": [
+      "poisonous",
+      "venom"
+    ],
     "kind": "inline",
     "asset": "assets/icons/poison.png",
     "notes": "Official Battle Systems poison icon."
   },
   "sharp": {
-    "aliases": ["blade", "wounding"],
+    "aliases": [
+      "blade",
+      "wounding"
+    ],
     "kind": "inline",
     "asset": "assets/icons/sharp.png",
     "notes": "Official Battle Systems sharp icon."
   },
   "size": {
-    "aliases": ["large", "small", "scale"],
+    "aliases": [
+      "large",
+      "small",
+      "scale"
+    ],
     "kind": "inline",
     "asset": "assets/icons/size.png",
     "notes": "Official Battle Systems size icon."
   },
   "grave": {
-    "aliases": ["grave-point"],
+    "aliases": [
+      "grave-point"
+    ],
     "kind": "footer",
     "asset": "assets/icons/grave.png",
     "notes": "Generated footer grave/skull icon derived from the approved sprite sheet."
   },
   "search": {
-    "aliases": ["inspect", "investigate"],
+    "aliases": [
+      "inspect",
+      "investigate"
+    ],
     "kind": "footer",
     "asset": "assets/icons/search.svg",
     "notes": "Search or inspect footer icon."
   },
   "arrow-up": {
-    "aliases": ["increase", "raise"],
+    "aliases": [
+      "increase",
+      "raise"
+    ],
     "kind": "footer",
     "asset": "assets/icons/arrow-up.png",
     "notes": "Generated footer increase icon derived from the approved sprite sheet."
   },
   "entry-point": {
-    "aliases": ["entry", "spawn-point"],
+    "aliases": [
+      "entry",
+      "spawn-point"
+    ],
     "kind": "footer",
     "asset": "assets/icons/entry-point.png",
     "notes": "Footer entry icon cropped from the original Trap! Net card art."
   },
   "map": {
-    "aliases": ["objective-map", "map-marker"],
+    "aliases": [
+      "objective-map",
+      "map-marker"
+    ],
     "kind": "footer",
     "asset": "assets/icons/map.png",
     "notes": "Generated footer map icon derived from the approved sprite sheet."
   },
   "wall": {
-    "aliases": ["brick-wall", "wall-terrain"],
+    "aliases": [
+      "brick-wall",
+      "wall-terrain"
+    ],
     "kind": "footer",
     "asset": "assets/icons/wall.png",
     "notes": "Generated footer wall icon derived from the approved sprite sheet."
   },
   "mountain": {
-    "aliases": ["peak", "mountain-area", "terrain-mountain"],
+    "aliases": [
+      "peak",
+      "mountain-area",
+      "terrain-mountain"
+    ],
     "kind": "footer",
     "asset": "assets/icons/mountain.png",
     "notes": "Local crop of the mountain footer icon from Treacherous Terrain."
   },
   "larger-area": {
-    "aliases": ["multi-level", "large-area"],
+    "aliases": [
+      "multi-level",
+      "large-area"
+    ],
     "kind": "footer",
     "asset": "assets/icons/larger-area.png",
     "notes": "Generated footer mines/area icon derived from the approved sprite sheet."
   },
   "worthy-opponent": {
-    "aliases": ["worthy_opponent", "renown-target"],
+    "aliases": [
+      "worthy_opponent",
+      "renown-target"
+    ],
     "kind": "inline",
     "asset": "assets/icons/worthy-opponent.png",
     "notes": "Official Battle Systems Worthy Opponent icon."
   },
   "revenant": {
-    "aliases": ["revenants", "revenant-card"],
+    "aliases": [
+      "revenants",
+      "revenant-card"
+    ],
     "kind": "inline",
     "asset": "assets/icons/revenant.svg",
     "notes": "Inline Revenant badge derived from the existing Revenant type art."
   },
   "blue-reminder": {
-    "aliases": ["blue reminder", "blue_reminder", "reminder-blue"],
+    "aliases": [
+      "blue reminder",
+      "blue_reminder",
+      "reminder-blue"
+    ],
     "kind": "inline",
     "asset": "assets/icons/blue-reminder.svg",
     "notes": "High-contrast blue reminder counter icon."
   },
   "red-reminder": {
-    "aliases": ["red reminder", "red_reminder", "reminder-red"],
+    "aliases": [
+      "red reminder",
+      "red_reminder",
+      "reminder-red"
+    ],
     "kind": "inline",
     "asset": "assets/icons/red-reminder.svg",
     "notes": "High-contrast red reminder counter icon."
   },
   "yellow-reminder": {
-    "aliases": ["yellow reminder", "yellow_reminder", "reminder-yellow"],
+    "aliases": [
+      "yellow reminder",
+      "yellow_reminder",
+      "reminder-yellow"
+    ],
     "kind": "inline",
     "asset": "assets/icons/yellow-reminder.svg",
     "notes": "High-contrast yellow reminder counter icon."
   },
   "actions": {
-    "aliases": ["action", "action-points", "turns"],
+    "aliases": [
+      "action",
+      "action-points",
+      "turns"
+    ],
     "kind": "inline",
     "asset": "assets/icons/actions.svg",
     "notes": "Dedicated action badge for stat lines and effect summaries."
   },
   "unknown-icon": {
-    "aliases": ["unknown"],
+    "aliases": [
+      "unknown"
+    ],
     "kind": "inline",
     "asset": "assets/icons/unknown-icon.svg",
     "notes": "Fallback placeholder for unresolved icon extraction."
+  },
+  "environment": {
+    "aliases": [
+      "environment-card",
+      "environment-icon"
+    ],
+    "kind": "footer",
+    "asset": "logos/Environment.jpg",
+    "notes": "Environment event-card emblem from the source card footer."
+  },
+  "dungeon": {
+    "aliases": [
+      "dungeon-card",
+      "dungeon-icon"
+    ],
+    "kind": "footer",
+    "asset": "logos/Dungeon.jpg",
+    "notes": "Dungeon event-card emblem from the source card footer."
+  },
+  "novice": {
+    "aliases": [
+      "novice-card",
+      "novice-icon"
+    ],
+    "kind": "footer",
+    "asset": "logos/Novice.jpg",
+    "notes": "Novice event-card emblem from the source card footer."
+  },
+  "veteran": {
+    "aliases": [
+      "veteran-card",
+      "veteran-icon"
+    ],
+    "kind": "footer",
+    "asset": "logos/Veteran.jpg",
+    "notes": "Veteran event-card emblem from the source card footer."
+  },
+  "malagaunt": {
+    "aliases": [
+      "malagaunt-card",
+      "malagaunt-icon"
+    ],
+    "kind": "footer",
+    "asset": "logos/Malagaunt.jpg",
+    "notes": "Malagaunt event-card emblem from the source card footer."
+  },
+  "wandering-beast": {
+    "aliases": [
+      "wandering beast",
+      "wandering_beast",
+      "beast-card"
+    ],
+    "kind": "footer",
+    "asset": "logos/WanderingBeast.jpg",
+    "notes": "Wandering Beast event-card emblem from the source card footer."
+  },
+  "cabal": {
+    "aliases": [
+      "cabal-card",
+      "cabal-icon"
+    ],
+    "kind": "footer",
+    "asset": "logos/Cabal.jpg",
+    "notes": "Cabal event-card emblem from the source card footer."
+  },
+  "location": {
+    "aliases": [
+      "location-pin",
+      "area-label",
+      "location-icon"
+    ],
+    "kind": "footer",
+    "asset": "logos/Location.jpg",
+    "notes": "Location pin used with printed footer area labels."
+  },
+  "vicious": {
+    "aliases": [
+      "vicious-rule",
+      "vicious-icon"
+    ],
+    "kind": "inline",
+    "asset": "assets/icons/vicious.svg",
+    "notes": "Source-matched red slash rule icon used for Vicious on Blaze of Glory."
+  },
+  "quickstrike": {
+    "aliases": [
+      "quick-strike",
+      "quickstrike-rule",
+      "quickstrike-icon"
+    ],
+    "kind": "inline",
+    "asset": "assets/icons/quickstrike.svg",
+    "notes": "Source-matched double-arrow rule icon used for Quickstrike on Blaze of Glory."
+  },
+  "cleave": {
+    "aliases": [
+      "cleave-rule",
+      "cleave-icon"
+    ],
+    "kind": "inline",
+    "asset": "assets/icons/cleave.svg",
+    "notes": "Source-matched crossed-weapon rule icon used for Cleave on Blaze of Glory."
+  },
+  "sundering": {
+    "aliases": [
+      "sunder",
+      "sundering-rule",
+      "sundering-icon"
+    ],
+    "kind": "inline",
+    "asset": "assets/icons/sundering.svg",
+    "notes": "Source-matched red cracked-shield rule icon used for Sundering."
+  },
+  "wounded": {
+    "aliases": [
+      "wound",
+      "wounded-counter",
+      "wounded-icon"
+    ],
+    "kind": "inline",
+    "asset": "assets/icons/wounded.svg",
+    "notes": "Source-matched blood-drop status icon used for Wounded."
+  },
+  "hit-and-run": {
+    "aliases": [
+      "hit and run",
+      "hit-run",
+      "hit-and-run-rule"
+    ],
+    "kind": "inline",
+    "asset": "assets/icons/hit-and-run.svg",
+    "notes": "Source-matched running rule icon used for Hit and Run."
+  },
+  "potion": {
+    "aliases": [
+      "potion-token",
+      "potion-icon"
+    ],
+    "kind": "inline",
+    "asset": "assets/icons/potion.svg",
+    "notes": "Source-matched purple potion item icon used on Stroke Of Fortune."
   }
 }

--- a/data/cards/oblivion-s-maw.json
+++ b/data/cards/oblivion-s-maw.json
@@ -31,17 +31,17 @@
         "left": [
           {
             "type": "icon",
-            "name": "malacytic-conduit"
+            "name": "corrupter"
           },
           {
             "type": "icon",
-            "name": "otherworldly"
+            "name": "wandering-beast"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "otherworldly"
           }
         ]
       },
@@ -53,12 +53,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "eldritch tentacle corrupter / wandering beast oblivion's maw todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "eldritch tentacle corrupter / wandering beast oblivion's maw corrupter wandering beast disquiet-dismay increase dread by 1. if the corrupter is in play, add a tentacle to its body if possible, or bless it if not, and discard this card. if the corrupter has been defeated, discard this card. otherwise, choose a random adventurer and scatter twice from their position, ignoring terrain. place a tentacle in the closest empty square to the target point. if an eldritch tentacle card is already in play, this tentacle will follow those rules and this card should be shuffled back into the deck. when activated, it will target any character in range of its attacks, other than the corrupter or another tentacle. if no characters are in range, it takes no actions. instead, draw and resolve an event card. when the tentacle is defeated it drops a severed tentacle, if available. mark the track on the corrupter campaign log, if applicable. leave this card in play. desperation-doom as above, but resolve all applicable effects twice. corrupter wandering-beast otherworldly"
     },
     {
       "id": 99,
@@ -72,12 +72,12 @@
       "sections": [
         {
           "kind": "mode",
-          "label": "Disquiet-Dismay",
+          "label": "DISQUIET-DISMAY",
           "text": "Increase Dread by 1. If the Corrupter is in play, add a tentacle to its body if possible, or Bless it if not, and discard this card. If the Corrupter has been defeated, discard this card.\n\nOtherwise, choose a random Adventurer and scatter twice from their position, ignoring terrain. Place a Tentacle in the closest empty square to the target point. If an Eldritch Tentacle card is already in play, this Tentacle will follow those rules and this card should be shuffled back into the deck.\n\nWhen activated, it will target any character in range of its attacks, other than the Corrupter or another Tentacle. If no characters are in range, it takes no actions. Instead, draw and resolve an Event card.\n\nWhen the Tentacle is defeated it drops a Severed Tentacle, if available. Mark the track on the Corrupter Campaign Log, if applicable. Leave this card in play."
         },
         {
           "kind": "mode",
-          "label": "Desperation-Doom",
+          "label": "DESPERATION-DOOM",
           "text": "As above, but resolve all applicable effects twice."
         }
       ],
@@ -85,11 +85,11 @@
         "left": [
           {
             "type": "icon",
-            "name": "malacytic-conduit"
+            "name": "corrupter"
           },
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": [
@@ -107,12 +107,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "eldritch tentacle corrupter / wandering beast oblivion's maw todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "eldritch tentacle corrupter / wandering beast oblivion's maw corrupter wandering beast disquiet-dismay increase dread by 1. if the corrupter is in play, add a tentacle to its body if possible, or bless it if not, and discard this card. if the corrupter has been defeated, discard this card. otherwise, choose a random adventurer and scatter twice from their position, ignoring terrain. place a tentacle in the closest empty square to the target point. if an eldritch tentacle card is already in play, this tentacle will follow those rules and this card should be shuffled back into the deck. when activated, it will target any character in range of its attacks, other than the corrupter or another tentacle. if no characters are in range, it takes no actions. instead, draw and resolve an event card. when the tentacle is defeated it drops a severed tentacle, if available. mark the track on the corrupter campaign log, if applicable. leave this card in play. desperation-doom as above, but resolve all applicable effects twice. corrupter wandering-beast otherworldly"
     },
     {
       "id": 100,
@@ -144,11 +144,11 @@
         "left": [
           {
             "type": "icon",
-            "name": "malacytic-conduit"
+            "name": "corrupter"
           },
           {
             "type": "icon",
-            "name": "otherworldly"
+            "name": "wandering-beast"
           }
         ],
         "right": [
@@ -166,12 +166,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.95,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "eldritch tentacle corrupter / wandering beast oblivion's maw todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "eldritch tentacle corrupter / wandering beast oblivion's maw corrupter wandering beast disquiet-dismay increase dread by 1. if the corrupter is in play, add a tentacle to its body if possible, or bless it if not, and discard this card. if the corrupter has been defeated, discard this card. otherwise, choose a random adventurer and scatter twice from their position, ignoring terrain. place a tentacle in the closest empty square to the target point. if an eldritch tentacle card is already in play, this tentacle will follow those rules and this card should be shuffled back into the deck. when activated, it will target any character in range of its attacks, other than the corrupter or another tentacle. if no characters are in range, it takes no actions. instead, draw and resolve an event card. when the tentacle is defeated it drops a severed tentacle, if available. mark the track on the corrupter campaign log, if applicable. leave this card in play. desperation-doom as above, but resolve all applicable effects twice. corrupter wandering-beast otherworldly"
     },
     {
       "id": 101,
@@ -193,7 +193,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "malacytic-conduit"
+            "name": "corrupter"
           }
         ],
         "right": []
@@ -205,12 +205,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "it's behind you! corrupter oblivion's maw todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "it's behind you! corrupter oblivion's maw corrupter disquiet-doom if the corrupter is in play, remove it. place it back onto the gaming area in any position where it can reach the largest number of enemies with its attacks. any characters already in these squares are moved aside to make space. then shuffle this card back into the deck. if the corrupter has been defeated, increase dread by 1 and discard this card. otherwise, if any tentacles are in play, remove the one furthest from any adventurers. choose a random adventurer and scatter from their position, ignoring terrain. replace the tentacle in the closest empty square to the target point. it activates immediately. then shuffle this card back into the deck. if no tentacles are in play, shuffle this card back into the deck and draw another. corrupter"
     },
     {
       "id": 102,
@@ -225,14 +225,14 @@
         {
           "kind": "mode",
           "label": "DISQUIET-DISMAY",
-          "text": "If you are playing the Oblivion’s Maw Campaign, increase Dread by 1, and then draw cards from the deck until you draw a [malacytic-conduit] or [enemy] card. Resolve that card, and then discard this card and any non-[malacytic-conduit] or [enemy] cards drawn.\n\nOtherwise, a Talisman has been discovered! Take a random Talisman from the supply, if possible, and add it to the Searchable terrain piece furthest from any Entry Points, even if already Searched. Mark one space on the Manifestation Track.\n\nThen, draw cards from the deck until you draw a [malacytic-conduit] or [enemy] card. Resolve that card, and then discard this card and any non-[malacytic-conduit] or [enemy] cards drawn."
+          "text": "If you are playing the Oblivion’s Maw Campaign, increase Dread by 1, and then draw cards from the deck until you draw a [corrupter] or [enemy] card. Resolve that card, and then discard this card and any non-[corrupter] or [enemy] cards drawn.\n\nOtherwise, a Talisman has been discovered! Take a random Talisman from the supply, if possible, and add it to the Searchable terrain piece furthest from any Entry Points, even if already Searched. Mark one space on the Manifestation Track.\n\nThen, draw cards from the deck until you draw a [corrupter] or [enemy] card. Resolve that card, and then discard this card and any non-[corrupter] or [enemy] cards drawn."
         }
       ],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "malacytic-conduit"
+            "name": "corrupter"
           }
         ],
         "right": []
@@ -244,12 +244,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "corrupt talisman corrupter oblivion's maw todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "corrupt talisman corrupter oblivion's maw corrupter disquiet-dismay if you are playing the oblivion’s maw campaign, increase dread by 1, and then draw cards from the deck until you draw a corrupter or enemy card. resolve that card, and then discard this card and any non- corrupter or enemy cards drawn. otherwise, a talisman has been discovered! take a random talisman from the supply, if possible, and add it to the searchable terrain piece furthest from any entry points, even if already searched. mark one space on the manifestation track. then, draw cards from the deck until you draw a corrupter or enemy card. resolve that card, and then discard this card and any non- corrupter or enemy cards drawn. corrupter"
     },
     {
       "id": 103,
@@ -263,12 +263,12 @@
       "sections": [
         {
           "kind": "mode",
-          "label": "Disquiet-Dismay",
+          "label": "DISQUIET-DISMAY",
           "text": "Energy leaches through dimensional boundaries. All Otherworldly [otherworldly] characters in play are Blessed. If no eligible characters are in play, increase Dread by 1 and shuffle this card back into the deck."
         },
         {
           "kind": "mode",
-          "label": "Desperation-Doom",
+          "label": "DESPERATION-DOOM",
           "text": "Energy surges through dimensional boundaries. All Otherworldly [otherworldly] characters in play activate immediately. They will activate again in the appropriate phase. If no eligible characters are in play, shuffle together all [enemy] cards not being used for this game that have the Otherworldly [otherworldly] icon and draw one at random. Resolve it immediately."
         }
       ],
@@ -276,7 +276,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -286,12 +286,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "ethereal power environment oblivion's maw todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "ethereal power environment oblivion's maw disquiet-dismay energy leaches through dimensional boundaries. all otherworldly otherworldly characters in play are blessed. if no eligible characters are in play, increase dread by 1 and shuffle this card back into the deck. desperation-doom energy surges through dimensional boundaries. all otherworldly otherworldly characters in play activate immediately. they will activate again in the appropriate phase. if no eligible characters are in play, shuffle together all enemy cards not being used for this game that have the otherworldly otherworldly icon and draw one at random. resolve it immediately. environment"
     },
     {
       "id": 104,
@@ -305,12 +305,12 @@
       "sections": [
         {
           "kind": "mode",
-          "label": "Disquiet-Distress",
+          "label": "DISQUIET-DISTRESS",
           "text": "An icy wind blasts through the halls. Determine a random Entry Point. All torches, sconces and Burning counters within medium range and with an open route to it are removed from play. All characters within medium range and with an open route to the Entry Point are Fatigued."
         },
         {
           "kind": "mode",
-          "label": "Dismay-Doom",
+          "label": "DISMAY-DOOM",
           "text": "As above, but resolve for two different Entry Points."
         }
       ],
@@ -318,7 +318,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -328,12 +328,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "deathly draught environment oblivion's maw todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "deathly draught environment oblivion's maw disquiet-distress an icy wind blasts through the halls. determine a random entry point. all torches, sconces and burning counters within medium range and with an open route to it are removed from play. all characters within medium range and with an open route to the entry point are fatigued. dismay-doom as above, but resolve for two different entry points. environment"
     },
     {
       "id": 105,
@@ -347,12 +347,12 @@
       "sections": [
         {
           "kind": "mode",
-          "label": "Disquiet-Dismay",
+          "label": "DISQUIET-DISMAY",
           "text": "You realise that certain parts of the tunnels open into gaping caverns or tall vertical shafts, with nothing but darkness where the ceiling should be – yet another place that enemies could be lurking...\n\nDetermine a random Adventurer and scatter from their position. Remove a random Entry Point and place it as close as possible to this location."
         },
         {
           "kind": "mode",
-          "label": "Desperation-Doom",
+          "label": "DESPERATION-DOOM",
           "text": "As above, but move two Entry Points, rolling separately for each."
         }
       ],
@@ -360,7 +360,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -370,12 +370,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.95,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "don't look up dungeon oblivion's maw todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "don't look up dungeon oblivion's maw disquiet-dismay you realise that certain parts of the tunnels open into gaping caverns or tall vertical shafts, with nothing but darkness where the ceiling should be – yet another place that enemies could be lurking... determine a random adventurer and scatter from their position. remove a random entry point and place it as close as possible to this location. desperation-doom as above, but move two entry points, rolling separately for each. dungeon"
     },
     {
       "id": 106,
@@ -389,7 +389,7 @@
       "sections": [
         {
           "kind": "mode",
-          "label": "Disquiet-Doom",
+          "label": "DISQUIET-DOOM",
           "text": "This is a particularly ancient part of the tunnel network, and old magics run through the very walls.\n\nAny unengaged Adventurers may spend a Magic peg to draw on these energies. They gain all the benefits of a Rest action as well as 1XP. However, your enemies feel this surge of power – for each Adventurer that spends a Magic peg, increase Dread by 2."
         }
       ],
@@ -397,7 +397,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -407,12 +407,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.95,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "halls of veneration dungeon oblivion's maw todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "halls of veneration dungeon oblivion's maw disquiet-doom this is a particularly ancient part of the tunnel network, and old magics run through the very walls. any unengaged adventurers may spend a magic peg to draw on these energies. they gain all the benefits of a rest action as well as 1xp. however, your enemies feel this surge of power – for each adventurer that spends a magic peg, increase dread by 2. dungeon"
     },
     {
       "id": 107,
@@ -431,7 +431,7 @@
         },
         {
           "kind": "box",
-          "label": "Character Rules",
+          "label": "",
           "text": "This character follows normal NPC activation rules considering all other characters to be enemies. Items taken with this character’s Plunderer [plunderer] rule are destroyed. When this character is defeated, it drops a random item from the token pouch."
         },
         {
@@ -444,7 +444,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": [
@@ -461,12 +461,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "cursed chest wandering beast oblivion's maw todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "cursed chest wandering beast oblivion's maw wandering beast disquiet-desperation determine the closest searchable terrain piece to an adventurer and replace it with a cursed chest. items inside the terrain piece are destroyed. activate the cursed chest immediately. this character follows normal npc activation rules considering all other characters to be enemies. items taken with this character’s plunderer plunderer rule are destroyed. when this character is defeated, it drops a random item from the token pouch. disaster-doom as above, but flip the cursed chest’s character board to the elite side. wandering-beast otherworldly"
     },
     {
       "id": 108,
@@ -480,12 +480,12 @@
       "sections": [
         {
           "kind": "mode",
-          "label": "Disquiet-Desperation",
+          "label": "DISQUIET-DESPERATION",
           "text": "Determine the closest door to an Adventurer. Close it and place a Cursed Portal on the side closest to the Adventurer, moving other characters aside if necessary. Activate the Cursed Portal immediately.\n\nThis character follows normal NPC activation rules considering all other characters to be enemies. If no characters are in range, it takes no actions. Instead, draw and resolve an Event card.\n\nAnyone defeated or Stunned by the Cursed Portal while in contact with it is removed from play and Left for Dead.\n\nThe door cannot be used. The other side of the door is treated as a portal (a dimensional portal if you have the Forbidden Creed expansion). When defeated, mark the door as destroyed."
         },
         {
           "kind": "mode",
-          "label": "Disaster-Doom",
+          "label": "DISASTER-DOOM",
           "text": "As above, but flip the Cursed Portal’s character board to the Elite side."
         }
       ],
@@ -493,13 +493,13 @@
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": [
           {
             "type": "icon",
-            "name": "malacytic-conduit"
+            "name": "otherworldly"
           }
         ]
       },
@@ -508,12 +508,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "cursed portal wandering beast oblivion's maw todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "cursed portal wandering beast oblivion's maw disquiet-desperation determine the closest door to an adventurer. close it and place a cursed portal on the side closest to the adventurer, moving other characters aside if necessary. activate the cursed portal immediately. this character follows normal npc activation rules considering all other characters to be enemies. if no characters are in range, it takes no actions. instead, draw and resolve an event card. anyone defeated or stunned by the cursed portal while in contact with it is removed from play and left for dead. the door cannot be used. the other side of the door is treated as a portal (a dimensional portal if you have the forbidden creed expansion). when defeated, mark the door as destroyed. disaster-doom as above, but flip the cursed portal’s character board to the elite side. wandering-beast otherworldly"
     },
     {
       "id": 109,
@@ -527,7 +527,7 @@
       "sections": [
         {
           "kind": "mode",
-          "label": "Disquiet-Desperation",
+          "label": "DISQUIET-DESPERATION",
           "text": "Place a pack of Cursed Vestiges at a random Entry Point and add a purple peg to the Dread tracker at the start of the band two higher than the current one, if possible. Activate the Cursed Vestiges immediately."
         },
         {
@@ -537,7 +537,7 @@
         },
         {
           "kind": "mode",
-          "label": "Disaster-Doom",
+          "label": "DISASTER-DOOM",
           "text": "As above, but flip the Cursed Vestiges’ character board to the Elite side."
         }
       ],
@@ -545,7 +545,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "wandering-beast"
           }
         ],
         "right": [
@@ -562,12 +562,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.95,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "cursed vestiges wandering beast oblivion's maw todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "cursed vestiges wandering beast oblivion's maw wandering beast disquiet-desperation place a pack of cursed vestiges at a random entry point and add a purple peg to the dread tracker at the start of the band two higher than the current one, if possible. activate the cursed vestiges immediately. these characters follow normal npc activation rules considering all other characters to be enemies. until the purple peg is replaced, or until the end of the game if there is no peg, when a cursed vestige is defeated it is replaced at a random entry point. disaster-doom as above, but flip the cursed vestiges’ character board to the elite side. wandering-beast otherworldly"
     },
     {
       "id": 110,
@@ -581,7 +581,7 @@
       "sections": [
         {
           "kind": "mode",
-          "label": "Disquiet-Doom",
+          "label": "DISQUIET-DOOM",
           "text": "Increase Dread by 2.\n\nProtective wards placed on this area in ages past suddenly activate, holding back anyone unworthy of entering a place of such power.\n\nEach Adventurer and Denizen in play rolls combat dice equal to the number of empty peg spaces in their dashboard. For each blunder [skull] rolled they suffer one Fatigue. Magic pegs may be spent to reduce the Fatigue suffered."
         }
       ],
@@ -589,11 +589,15 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
+          },
+          {
+            "type": "label",
+            "text": "+"
           },
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -603,12 +607,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.95,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "trap! ancient wards veteran + dungeon oblivion's maw todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "trap! ancient wards veteran + dungeon oblivion's maw disquiet-doom increase dread by 2. protective wards placed on this area in ages past suddenly activate, holding back anyone unworthy of entering a place of such power. each adventurer and denizen in play rolls combat dice equal to the number of empty peg spaces in their dashboard. for each blunder skull rolled they suffer one fatigue. magic pegs may be spent to reduce the fatigue suffered. veteran + dungeon"
     },
     {
       "id": 111,
@@ -630,11 +634,15 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
+          },
+          {
+            "type": "label",
+            "text": "+"
           },
           {
             "type": "icon",
-            "name": "larger-area"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -644,12 +652,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.95,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "trap! crushing ceiling veteran + dungeon oblivion's maw todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "trap! crushing ceiling veteran + dungeon oblivion's maw disquiet-doom doors slam shut all around and you hear a sound of grinding stone as the ceiling bears down on you! choose a random adventurer. all doors in their room are closed and locked. all other openings are also marked as locked. add a purple peg to the dread tracker 5 spaces ahead of the current dread. place this card next to the dread tracker. adversaries outside the room will not target the characters inside or enter the room while this is in play. blockages in openings must be destroyed as if they were locked doors. unengaged characters in the room may spend an action to attempt to prop the ceiling up – move the purple peg in the tracker one space up. when the purple peg is replaced, all characters in the room are defeated, the doors/openings will unlock/unblock, and the ceiling will return to normal – discard this card. veteran + dungeon"
     },
     {
       "id": 112,
@@ -671,7 +679,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -683,12 +691,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "summon the master... veteran oblivion's maw todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "summon the master... veteran oblivion's maw veteran disquiet-doom increase dread by 2. then, if the adversary commander cards (e.g. enemy unless using other adversaries) are not used in the current quest, take them from the supply and shuffle them into the deck. if they are already being used for this quest, draw and resolve another event card. veteran"
     }
   ]
 }

--- a/data/cards/of-ale-and-adventure.json
+++ b/data/cards/of-ale-and-adventure.json
@@ -41,12 +41,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "questgiver denizen of ale and adventure todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "questgiver denizen of ale and adventure disquiet-dismay select a random denizen. it gains two additional health pegs, one additional magic peg, one random uncommon weapon and one random item from the token pouch. place it at a random entry point. when activated, the character moves towards the nearest adventurer. it will not engage enemies – it will stop one square away if there is no route around. if it starts its turn engaged, it will make a melee attack if possible, or a knock back if not. if still engaged it will move directly away if possible, or attack/knock back again if not. it resumes its normal rules for any remaining actions. if this character makes contact with an adventurer, that player draws a side quest card and resolves it. discard this card – for the rest of the game the questgiver will act as detailed in the side quest. desperation-doom it’s too late for this adventurer’s quest, but not for yours! all adventurers in play are blessed. denizen"
     },
     {
       "id": 52,
@@ -85,12 +85,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "questgiver denizen of ale and adventure todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "questgiver denizen of ale and adventure denizen disquiet-dismay select a random denizen. it gains two additional health pegs, one additional magic peg, one random uncommon weapon and one random item from the token pouch. place it at a random entry point. when activated, the character moves towards the nearest adventurer. it will not engage enemies – it will stop one square away if there is no route around. if it starts its turn engaged, it will make a melee attack if possible, or a knock back if not. if still engaged it will move directly away if possible, or attack/knock back again if not. it resumes its normal rules for any remaining actions. if this character makes contact with an adventurer, that player draws a side quest card and resolves it. discard this card – for the rest of the game the questgiver will act as detailed in the side quest. desperation-doom it’s too late for this adventurer’s quest, but not for yours! all adventurers in play are blessed. denizen"
     },
     {
       "id": 53,
@@ -105,7 +105,7 @@
         {
           "kind": "mode",
           "label": "DISQUIET-DOOM",
-          "text": "Select a random Denizen. It gains one additional Health peg, one random uncommon weapon and one random item from the token pouch. Place it at a random Entry Point.\n\nThis character follows normal NPC activation rules but only targets characters with equipment that have not been Searched (see below). It has Plunderer [plunderer] and Hit and Run [move:3] and will only attack within short range. Before it attacks, the defender may choose to give the attacker G.5 or an item from their inventory to cancel the attack. Mark the defender with a Searched counter.\n\nThis NPC will not target or engage Searched enemies or those without equipment. If engaged with one, when activated it will use its first action to make a Melee attack and its Hit and Run ability to move away before continuing its turn.\n\nOnce its inventory is full it will leave via the nearest Entry Point."
+          "text": "Select a random Denizen. It gains one additional Health peg, one random uncommon weapon and one random item from the token pouch. Place it at a random Entry Point.\n\nThis character follows normal NPC activation rules but only targets characters with equipment that have not been Searched (see below). It has Plunderer [plunderer] and Hit and Run [hit-and-run] and will only attack within short range. Before it attacks, the defender may choose to give the attacker G.5 or an item from their inventory to cancel the attack. Mark the defender with a Searched counter.\n\nThis NPC will not target or engage Searched enemies or those without equipment. If engaged with one, when activated it will use its first action to make a Melee attack and its Hit and Run ability to move away before continuing its turn.\n\nOnce its inventory is full it will leave via the nearest Entry Point."
         }
       ],
       "footer": {
@@ -124,12 +124,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "stand and deliver! denizen of ale and adventure todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "stand and deliver! denizen of ale and adventure denizen disquiet-doom select a random denizen. it gains one additional health peg, one random uncommon weapon and one random item from the token pouch. place it at a random entry point. this character follows normal npc activation rules but only targets characters with equipment that have not been searched (see below). it has plunderer plunderer and hit and run hit-and-run and will only attack within short range. before it attacks, the defender may choose to give the attacker g.5 or an item from their inventory to cancel the attack. mark the defender with a searched counter. this npc will not target or engage searched enemies or those without equipment. if engaged with one, when activated it will use its first action to make a melee attack and its hit and run ability to move away before continuing its turn. once its inventory is full it will leave via the nearest entry point. denizen"
     },
     {
       "id": 54,
@@ -143,12 +143,7 @@
       "sections": [
         {
           "kind": "mode",
-          "label": "Bounty!",
-          "text": "DISQUIET-DOOM"
-        },
-        {
-          "kind": "body",
-          "label": "",
+          "label": "DISQUIET-DOOM",
           "text": "Select a random Denizen. It gains two Health pegs, one Magic peg, one uncommon ranged weapon, one uncommon melee weapon, one uncommon armour token, and one item from the pouch. Place it at a random Entry Point. Select one random Adventurer/Denizen per three in play, rounding up, distributed evenly between parties. Mark them with a Reminder counter.\nThis character follows normal NPC activation rules but only targets marked characters. If it engages an enemy, it will attempt to defeat it before resuming its normal rules.\nBefore it first attacks a marked character, roll the Magic Die.\n1-3: It wants them dead and will attack until they are defeated. Once defeated, it will make a melee attack to permanently kill the character.\n4-6: It wants them alive. Its attacks against the target gain Bludgeoning [bludgeoning]. If the target's last health would be taken, Stun them instead. Once a target is Stunned, this character will drag them off via the nearest Entry Point. Characters in contact with this Denizen cannot remove their Stun status. Characters dragged off are Left for Dead.\nIf no eligible targets remain it will leave."
         }
       ],
@@ -168,12 +163,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.95,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "bounty! denizen of ale and adventure todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "bounty! denizen of ale and adventure denizen disquiet-doom select a random denizen. it gains two health pegs, one magic peg, one uncommon ranged weapon, one uncommon melee weapon, one uncommon armour token, and one item from the pouch. place it at a random entry point. select one random adventurer/denizen per three in play, rounding up, distributed evenly between parties. mark them with a reminder counter. this character follows normal npc activation rules but only targets marked characters. if it engages an enemy, it will attempt to defeat it before resuming its normal rules. before it first attacks a marked character, roll the magic die. 1-3: it wants them dead and will attack until they are defeated. once defeated, it will make a melee attack to permanently kill the character. 4-6: it wants them alive. its attacks against the target gain bludgeoning bludgeoning . if the target's last health would be taken, stun them instead. once a target is stunned, this character will drag them off via the nearest entry point. characters in contact with this denizen cannot remove their stun status. characters dragged off are left for dead. if no eligible targets remain it will leave. denizen"
     },
     {
       "id": 55,
@@ -205,12 +200,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.95,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "nomadic trader denizen of ale and adventure todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "nomadic trader denizen of ale and adventure disquiet-doom select a random denizen. it gains one additional health peg and two random items from the pouch. place it at a random entry point. when activated, if in short range of an adventurer the character will move towards the closest. otherwise, it scatters once per action. it will not engage enemies – it will stop one square away. if engaged, when activated it will use its first action to make a melee attack, and its second to move directly away. the character is here to sell their wares. when an adventurer first enters contact with the npc, set aside 5 items from the pouch, 5 uncommon items, and 2 rare items at random. any number of items can be purchased by persuading the npc. each unblocked hit (if any) reduces the cost of each item by g1 (to a min. of g1). these items are not in the npc’s inventory and cannot be taken in any other way. if the npc is defeated the items are returned to the supply. if all items are purchased, the npc will leave via the nearest entry point. denizen"
     },
     {
       "id": 56,
@@ -225,7 +220,7 @@
         {
           "kind": "mode",
           "label": "DISQUIET-DOOM",
-          "text": "Select a random Denizen. It gains one additional Health peg, two additional Magic pegs, one random uncommon item and one random rare item. Place it at a random Entry Point.\nWhen activated, the character Moves towards the nearest Adventurer – its chosen ‘guide’. Once contact is made, it will instead Move towards the nearest unsearched room, or the guiding party’s Staging Point if all rooms are Searched.\nIf the character engages an enemy, it will use an action to attempt to talk to it – Fatigue the enemy. The character will then resume its normal rules, moving away from and past the enemy.\nIf this character leaves play via a Staging Point the rescuing player gains [fire]20.\nIf this Denizen is defeated, the ‘guiding’ party (or closest party if it has not yet made contact) loses two Renown."
+          "text": "Select a random Denizen. It gains one additional Health peg, two additional Magic pegs, one random uncommon item and one random rare item. Place it at a random Entry Point.\nWhen activated, the character Moves towards the nearest Adventurer – its chosen ‘guide’. Once contact is made, it will instead Move towards the nearest unsearched room, or the guiding party’s Staging Point if all rooms are Searched.\nIf the character engages an enemy, it will use an action to attempt to talk to it – Fatigue the enemy. The character will then resume its normal rules, moving away from and past the enemy.\nIf this character leaves play via a Staging Point the rescuing player gains G20.\nIf this Denizen is defeated, the ‘guiding’ party (or closest party if it has not yet made contact) loses two Renown."
         }
       ],
       "footer": {
@@ -244,12 +239,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "excursionist denizen of ale and adventure todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "excursionist denizen of ale and adventure denizen disquiet-doom select a random denizen. it gains one additional health peg, two additional magic pegs, one random uncommon item and one random rare item. place it at a random entry point. when activated, the character moves towards the nearest adventurer – its chosen ‘guide’. once contact is made, it will instead move towards the nearest unsearched room, or the guiding party’s staging point if all rooms are searched. if the character engages an enemy, it will use an action to attempt to talk to it – fatigue the enemy. the character will then resume its normal rules, moving away from and past the enemy. if this character leaves play via a staging point the rescuing player gains g20. if this denizen is defeated, the ‘guiding’ party (or closest party if it has not yet made contact) loses two renown. denizen"
     },
     {
       "id": 57,
@@ -263,7 +258,7 @@
       "sections": [
         {
           "kind": "mode",
-          "label": "Disquiet-Doom",
+          "label": "DISQUIET-DOOM",
           "text": "Select a random Denizen. It gains one random item from the token pouch. Place it at a random Entry Point."
         },
         {
@@ -286,12 +281,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "panhandler denizen of ale and adventure todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "panhandler denizen of ale and adventure disquiet-doom select a random denizen. it gains one random item from the token pouch. place it at a random entry point. when activated, the character moves towards the nearest adventurer. once in contact, it will use its actions to fatigue the adventurer. an adventurer in contact may spend g.5 or discard a provisions to mark this card as searched. the denizen will no longer follow the rules above; instead it will scatter once per action. it will not engage enemies – it will stop one square away if there is no route around. if it starts its turn engaged, it will make a knock back action. if still engaged it will move directly away if possible, or knock back again if not. it resumes its normal rules for any remaining actions. if this denizen is defeated, all parties in play lose one renown. denizen"
     },
     {
       "id": 58,
@@ -325,12 +320,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "wanderer denizen of ale and adventure todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "wanderer denizen of ale and adventure denizen disquiet-doom select a random denizen. it gains two random items from the token pouch. place it at a random entry point. the character does not use its regular actions. instead, when activated, roll the magic die and resolve as follows: 1-2: scatter the character once for each action. 3: use the character’s actions to move towards the nearest adventurer. once in contact, use its actions to fatigue the adventurer. 4-5: use the character’s actions to move to a position out of sight or in cover from the most other characters. 6: follow normal npc rules, targeting the closest character. denizen"
     },
     {
       "id": 59,
@@ -343,12 +338,12 @@
       "renderMode": "rich",
       "sections": [
         {
-          "kind": "body",
+          "kind": "mode",
           "label": "DISQUIET-DISMAY",
           "text": "An Adventurer spots something that reminds them of a rumour they heard on a drunken evening – maybe there’s some truth to it?\n\nDraw a Side Quest card at random and resolve it. Follow the Questgiver instructions if applicable, albeit with no Questgiver in play (they are not considered defeated). If this is not possible, discard the Side Quest and draw another."
         },
         {
-          "kind": "body",
+          "kind": "mode",
           "label": "DESPERATION-DOOM",
           "text": "Something catches your eye and triggers a memory. Distracted in the heat of battle, you can’t quite remember the full story, but there was something about a hidden compartment…\n\nSelect one of your Adventurers at random. Add a random rare item to the nearest Searchable terrain piece to that Adventurer, even if it has already been Searched."
         }
@@ -357,7 +352,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "map"
+            "name": "environment"
           }
         ],
         "right": []
@@ -367,12 +362,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
-        "confidence": 0.95,
+        "status": "verified",
+        "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "rumours environment of ale and adventure todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "rumours environment of ale and adventure disquiet-dismay an adventurer spots something that reminds them of a rumour they heard on a drunken evening – maybe there’s some truth to it? draw a side quest card at random and resolve it. follow the questgiver instructions if applicable, albeit with no questgiver in play (they are not considered defeated). if this is not possible, discard the side quest and draw another. desperation-doom something catches your eye and triggers a memory. distracted in the heat of battle, you can’t quite remember the full story, but there was something about a hidden compartment… select one of your adventurers at random. add a random rare item to the nearest searchable terrain piece to that adventurer, even if it has already been searched. environment"
     },
     {
       "id": 60,
@@ -394,7 +389,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "novice"
           }
         ],
         "right": []
@@ -404,12 +399,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "escape route novice of ale and adventure todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "escape route novice of ale and adventure disquiet-doom the first player keeps this card, without showing the other players. you’ve spotted an unguarded way out, but the window of opportunity is only big enough for one. you may discard this card when a character activates. that character may use any entry point to leave the board this round and return to their staging area. no adversaries will arrive from the chosen entry point this round – re-roll the arrival location if necessary. alternatively, you may keep this card until after the game to add 3 to a left for dead roll in the escape phase. novice"
     },
     {
       "id": 61,
@@ -431,7 +426,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "novice"
           }
         ],
         "right": []
@@ -443,12 +438,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "it's a trap! novice of ale and adventure todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "it's a trap! novice of ale and adventure novice disquiet-doom the first player keeps this card, without showing the other players. play this card during one of your adventurer's turns. they have a brainwave and jury-rig a trap—they make an interact action and discard an item of their choice. choose a trap token from the pouch of up to the same size as the discarded item and place it adjacent to the adventurer. npcs are unaware of the trap and will not adjust their route to avoid it. the trap is triggered immediately when an enemy enters an adjacent square and its effects are resolved against that enemy. then flip the token face down – it will not resolve again this round. flip it face up again in the assessment phase. each time the trap is resolved, roll a die. on a skull , discard the token. place this card to the side of the board as a reminder and discard it when the trap is removed. novice"
     },
     {
       "id": 62,
@@ -470,7 +465,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "novice"
           }
         ],
         "right": []
@@ -480,12 +475,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "outta my way! novice of ale and adventure todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "outta my way! novice of ale and adventure disquiet-doom the first player keeps this card, without showing the other players. you may discard this card at the start of one of your adventurer’s turns if they have at least three enemies in short range. the adventurer has been cornered and their fight or flight responses get all mixed up into an enraged outburst. all enemies of up to the adventurer’s size that are within short range and los suffer two fatigue counters. all enemies engaged with the adventurer are also knocked prone. novice"
     },
     {
       "id": 63,
@@ -500,14 +495,14 @@
         {
           "kind": "mode",
           "label": "DISQUIET-DOOM",
-          "text": "The first player keeps this card, without showing the other players.\n\nYou feel different, as if someone’s watching out for you. You may discard this card at any of the following times:\n\n- Before making a Search to gain a Potion of your choice in addition to anything else you find. Traps found during this Search are discarded with no effect.\n- When in contact with a locked door to unlock the door.\n- Before an enemy attacks one of your Adventurers to ignore all effects of the attack."
+          "text": "The first player keeps this card, without showing the other players.\n\nYou feel different, as if someone’s watching out for you. You may discard this card at any of the following times:\n\n- Before making a Search to gain a Potion [potion] of your choice in addition to anything else you find. Traps found during this Search are discarded with no effect.\n- When in contact with a locked door to unlock the door.\n- Before an enemy attacks one of your Adventurers to ignore all effects of the attack."
         }
       ],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "novice"
           }
         ],
         "right": []
@@ -517,12 +512,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "stroke of fortune novice of ale and adventure todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "stroke of fortune novice of ale and adventure disquiet-doom the first player keeps this card, without showing the other players. you feel different, as if someone’s watching out for you. you may discard this card at any of the following times: - before making a search to gain a potion potion of your choice in addition to anything else you find. traps found during this search are discarded with no effect. - when in contact with a locked door to unlock the door. - before an enemy attacks one of your adventurers to ignore all effects of the attack. novice"
     },
     {
       "id": 64,
@@ -540,7 +535,7 @@
           "text": "Increase Dread by 1 and shuffle this card back into the deck. Then, draw and resolve another Event Card."
         },
         {
-          "kind": "body",
+          "kind": "mode",
           "label": "DISMAY-DOOM",
           "text": "Increase Dread by 1.\n\nThe lights have gone out. The whole gaming area follows the rules for Darkness for the rest of this quest. Remove any Darkness counters. Sconces and any other light sources remain in place.\n\nIf the Darkness rules are already in effect for this quest, all Adventurers and Denizens currently in the dark become Terrified."
         }
@@ -549,11 +544,15 @@
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
+          },
+          {
+            "type": "label",
+            "text": "+"
           },
           {
             "type": "icon",
-            "name": "entry-point"
+            "name": "dungeon"
           }
         ],
         "right": []
@@ -566,12 +565,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "lights out veteran + dungeon of ale and adventure todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "lights out veteran + dungeon of ale and adventure veteran dungeon disquiet-distress increase dread by 1 and shuffle this card back into the deck. then, draw and resolve another event card. dismay-doom increase dread by 1. the lights have gone out. the whole gaming area follows the rules for darkness for the rest of this quest. remove any darkness counters. sconces and any other light sources remain in place. if the darkness rules are already in effect for this quest, all adventurers and denizens currently in the dark become terrified. veteran + dungeon"
     },
     {
       "id": 65,
@@ -585,24 +584,20 @@
       "sections": [
         {
           "kind": "mode",
-          "label": "Disquiet",
+          "label": "DISQUIET",
           "text": "The Adventurers feel something changing, a shift in the magical energy that surrounds them.\n\nIf the Dread board is on side A, flip it to side B. Whether the board was flipped or not, shuffle this card back into the deck.\n\nCollectively, Adventurers may spend a number of Magic pegs equal to the number of characters in play to resist the changing energy. Each rolls the Magic Die separately. If sufficient pegs are spent, the above effects are cancelled."
         },
         {
           "kind": "mode",
-          "label": "Distress-Doom",
-          "text": "The unnerving surge of energy has returned.\n\nIf the Dread board is on side B, flip it to side A. If the board was not flipped, shuffle all Adversary cards (e.g. [Revenant] unless using other Adversaries) in the discard pile back into the deck.\n\nAdventurers may collectively spend Magic pegs as above to cancel this effect."
+          "label": "DISTRESS-DOOM",
+          "text": "The unnerving surge of energy has returned.\n\nIf the Dread board is on side B, flip it to side A. If the board was not flipped, shuffle all Adversary cards (e.g. [revenant] unless using other Adversaries) in the discard pile back into the deck.\n\nAdventurers may collectively spend Magic pegs as above to cancel this effect."
         }
       ],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "arrow-up"
-          },
-          {
-            "type": "icon",
-            "name": "grave"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -614,12 +609,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "paradigm shift veteran of ale and adventure todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "paradigm shift veteran of ale and adventure veteran disquiet the adventurers feel something changing, a shift in the magical energy that surrounds them. if the dread board is on side a, flip it to side b. whether the board was flipped or not, shuffle this card back into the deck. collectively, adventurers may spend a number of magic pegs equal to the number of characters in play to resist the changing energy. each rolls the magic die separately. if sufficient pegs are spent, the above effects are cancelled. distress-doom the unnerving surge of energy has returned. if the dread board is on side b, flip it to side a. if the board was not flipped, shuffle all adversary cards (e.g. revenant unless using other adversaries) in the discard pile back into the deck. adventurers may collectively spend magic pegs as above to cancel this effect. veteran"
     }
   ]
 }

--- a/data/cards/revenant-retribution.json
+++ b/data/cards/revenant-retribution.json
@@ -31,7 +31,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "revenant"
           },
           {
             "type": "label",
@@ -39,7 +39,7 @@
           },
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -52,12 +52,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "high alert revenant + veteran revenant retribution todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "high alert revenant + veteran revenant retribution revenant veteran disquiet-desperation take the revenant reinforcements from the box and add them to the supply. they will be available for use for the rest of the game. then, draw another event card, resolving it as if the dread were one band higher than it is. in addition, when determining which adversaries will arrive this round, consider the dread to be one band higher than it is. discard this card after resolving adversary arrival. disaster-doom take the revenant reinforcements from the box and add them to the supply. they will be available for use for the rest of the game. then, flip the adversary board to the reverse side, if not already flipped. all adversaries in play immediately take one action following the normal rules. revenant + veteran"
     },
     {
       "id": 85,
@@ -79,7 +79,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "grave"
+            "name": "revenant"
           },
           {
             "type": "label",
@@ -87,7 +87,7 @@
           },
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -97,12 +97,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "fortune favours the grave revenant + veteran revenant retribution todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "fortune favours the grave revenant + veteran revenant retribution disquiet-doom increase dread by 1. take the revenant reinforcements from the box and add them to the supply. they will be available for use for the rest of the game. then, a blessed lamentor is place on every grave point within short range of an adventurer. revenant + veteran"
     },
     {
       "id": 86,
@@ -124,7 +124,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "creature"
+            "name": "revenant"
           },
           {
             "type": "label",
@@ -132,7 +132,7 @@
           },
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -142,17 +142,17 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "lurching forth revenant + veteran revenant retribution todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "lurching forth revenant + veteran revenant retribution disquiet-doom increase dread by 1. take the revenant reinforcements from the box and add them to the supply. they will be available for use for the rest of the game. resolve adversary arrival for the round. you will resolve adversary arrival again in the adversary phase as normal. revenant + veteran"
     },
     {
       "id": 87,
       "card": "Dead-Jà Vu",
-      "slug": "dead-j-vu",
+      "slug": "dead-ja-vu",
       "type": "Revenant + Veteran",
       "game": "Revenant Retribution",
       "sourceImage": "Dead_Ja_Vu.png",
@@ -162,19 +162,19 @@
         {
           "kind": "mode",
           "label": "DISQUIET-DISTRESS",
-          "text": "Increase Dread by 1.\n\nTake the topmost card from the discard pile (ignoring [arrow-up] cards) and resolve it again, if possible. Then shuffle this card back into the deck."
+          "text": "Increase Dread by 1.\n\nTake the topmost card from the discard pile (ignoring [veteran] cards) and resolve it again, if possible. Then shuffle this card back into the deck."
         },
         {
           "kind": "mode",
           "label": "DISMAY-DOOM",
-          "text": "Increase Dread by 1.\n\nTake the Revenant Reinforcements from the box and add them to the supply. They will be available for use for the rest of the game.\n\nThen take all [grave] cards from the discard pile. Select one at random and resolve it. Shuffle the others back into the deck."
+          "text": "Increase Dread by 1.\n\nTake the Revenant Reinforcements from the box and add them to the supply. They will be available for use for the rest of the game.\n\nThen take all [revenant] cards from the discard pile. Select one at random and resolve it. Shuffle the others back into the deck."
         }
       ],
       "footer": {
         "left": [
           {
             "type": "icon",
-            "name": "grave"
+            "name": "revenant"
           },
           {
             "type": "label",
@@ -182,7 +182,7 @@
           },
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -195,12 +195,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "dead-jà vu revenant + veteran revenant retribution increase dread discard pile arrow-up revenant reinforcements grave"
+      "searchText": "dead-jà vu revenant + veteran revenant retribution revenant veteran disquiet-distress increase dread by 1. take the topmost card from the discard pile (ignoring veteran cards) and resolve it again, if possible. then shuffle this card back into the deck. dismay-doom increase dread by 1. take the revenant reinforcements from the box and add them to the supply. they will be available for use for the rest of the game. then take all revenant cards from the discard pile. select one at random and resolve it. shuffle the others back into the deck. revenant + veteran"
     },
     {
       "id": 88,
@@ -218,7 +218,7 @@
           "text": "Increase Dread by 1 and shuffle this card back into the deck. Then, draw and resolve another Event Card."
         },
         {
-          "kind": "body",
+          "kind": "mode",
           "label": "DISMAY-DOOM",
           "text": "Take the Revenant Reinforcements from the box and add them to the supply. They will be available for use for the rest of the game.\n\nThen, if the Malagaunt or Deathly Avatar is in play, Bless it and raise Dread by 2.\n\nOtherwise, place a Myria at a random Entry Point and mark it with a Reminder counter. If all Myria are in play, mark the one furthest from any enemies with a Reminder counter.\n\nThe marked Myria will use the Deathly Avatar character board and dashboard."
         }
@@ -227,7 +227,7 @@
         "left": [
           {
             "type": "icon",
-            "name": "otherworldly"
+            "name": "revenant"
           },
           {
             "type": "label",
@@ -235,7 +235,7 @@
           },
           {
             "type": "icon",
-            "name": "arrow-up"
+            "name": "veteran"
           }
         ],
         "right": []
@@ -245,12 +245,12 @@
         "style": "inline-bracket"
       },
       "extraction": {
-        "status": "auto",
+        "status": "verified",
         "confidence": 1,
         "issues": [],
-        "managedBy": "extractor"
+        "managedBy": "human"
       },
-      "searchText": "deathly avatar revenant + veteran revenant retribution todo todo - requires manual entry unknown-icon unknown-icon"
+      "searchText": "deathly avatar revenant + veteran revenant retribution disquiet-distress increase dread by 1 and shuffle this card back into the deck. then, draw and resolve another event card. dismay-doom take the revenant reinforcements from the box and add them to the supply. they will be available for use for the rest of the game. then, if the malagaunt or deathly avatar is in play, bless it and raise dread by 2. otherwise, place a myria at a random entry point and mark it with a reminder counter. if all myria are in play, mark the one furthest from any enemies with a reminder counter. the marked myria will use the deathly avatar character board and dashboard. revenant + veteran"
     }
   ]
 }

--- a/deck-rules.js
+++ b/deck-rules.js
@@ -9,7 +9,6 @@ export function buildDeck({
     availableCards = [],
     dataStore = {},
     cardCounts = {},
-    specialCardCounts = {},
     sentryCardCounts = {},
     enableSentryRules = false,
     enableCorrupterRules = false,
@@ -22,7 +21,6 @@ export function buildDeck({
     const heldBackCardTypes = dataStore.heldBackCardTypes || [];
     const selectedCardsMap = new Map();
     const regularCounts = { ...cardCounts };
-    const specialCounts = { ...specialCardCounts };
     const sentryCounts = { ...sentryCardCounts };
     const allAvailableCards = [...availableCards];
 
@@ -36,10 +34,10 @@ export function buildDeck({
     });
 
     let mainDeck = [];
-    let specialDeck = [];
+    // Retain the state shape; Corrupters replace main-deck cards instead of forming a separate deck.
+    const specialDeck = [];
     let sentryDeck = [];
     let hasRegularCardSelection = false;
-    let hasSpecialCardSelection = false;
 
     allCardTypes.forEach(type => {
         if (sentryTypes.includes(type) && enableSentryRules) return;
@@ -54,18 +52,6 @@ export function buildDeck({
         }
     });
 
-    if (enableCorrupterRules) {
-        allCardTypes.forEach(type => {
-            if (!corrupterTypes.includes(type)) return;
-            const count = specialCounts[type];
-            if (count > 0) {
-                hasSpecialCardSelection = true;
-                const selected = selectCardsByType(type, count, selectedCardsMap, specialCounts, allAvailableCards, shuffle);
-                specialDeck = specialDeck.concat(selected);
-            }
-        });
-    }
-
     if (enableSentryRules) {
         allCardTypes.forEach(type => {
             if (!sentryTypes.includes(type)) return;
@@ -77,22 +63,18 @@ export function buildDeck({
         });
     }
 
-    if (!hasRegularCardSelection && !hasSpecialCardSelection && sentryDeck.length === 0) {
+    if (!hasRegularCardSelection && sentryDeck.length === 0) {
         return { error: DECK_RULE_ERRORS.emptySelection };
     }
 
     if (enableCorrupterRules && mainDeck.length >= corrupterReplacementCount) {
-        const replacementPool = specialDeck.length > 0
-            ? specialDeck
-            : getSpecialCards(corrupterReplacementCount, corrupterTypes, deckDataByType, shuffle);
+        const replacementPool = getSpecialCards(corrupterReplacementCount, corrupterTypes, deckDataByType, shuffle);
         const corrupterCards = shuffle([...replacementPool]).slice(0, corrupterReplacementCount);
 
         if (corrupterCards.length > 0) {
             mainDeck.splice(0, corrupterCards.length);
             mainDeck = mainDeck.concat(corrupterCards);
         }
-
-        specialDeck = [];
     }
 
     mainDeck = shuffle(mainDeck);

--- a/docs/adr/0001-consolidate-rich-event-cards.md
+++ b/docs/adr/0001-consolidate-rich-event-cards.md
@@ -1,0 +1,42 @@
+# ADR 0001: Consolidate Rich Event Cards into the Main Project
+
+- Status: Accepted
+- Date: 2026-08-14
+
+## Context
+
+`BarryRodick/maladum-rich-event-cards` was split from the rich-card work that ended at main-project commit `0a68b63`. Both repositories then changed independently. The main project developed the newer live-deck and campaign architecture, while the split project completed the structured-card fidelity review and retained two useful deck-behaviour fixes.
+
+The split repository has unrelated Git history, so merging its root would duplicate the application and obscure the main project's history.
+
+## Decision
+
+`BarryRodick/MaladumEventCards` is the sole canonical project.
+
+The split repository is reconciled by porting reviewed outcomes, not by merging unrelated histories:
+
+| Split-project work | Disposition |
+| --- | --- |
+| `7f68faf` rich-card fidelity review | Port the final seven card files, extraction report, icon registry, seven SVG icons, accent-insensitive search, fidelity tests, and icon sizing constraints. |
+| `9a10f75` Sudden Rot verification | Port the verified food list and its regression coverage. |
+| `d2ff015` architecture refactor | Keep main's later architecture. Port only the `shuffleTopN` next-card fix and fixed five-card Corrupter replacement behaviour. |
+| `44286bf` Dungeons achievement wiring | Do not copy. Main's campaign tracker already captures every `.checkbox`, including achievements. |
+| `3fdc44b` cache version bump | Superseded by main's version and generated service-worker manifest. |
+| `68ea6f5` printed card text order | Remove the synthetic type/game row from rich-card rendering and retain the printed title-to-section order. |
+| Local-only `3cd0de3` agent setup | Do not port as product code. Main already has its own local agent guidance and issue-tracker conventions. |
+
+Main's defensive catalog normalization, saved-state hydration, live-deck session/view modules, campaign accessibility support, package identity, dependency versions, and service-worker generation remain authoritative.
+
+## Branch Disposition
+
+At the time of this decision, the main GitHub repository had 12 non-main remote branches. `codex/setup-cleanup-2026-04-29` was already merged. The other 11 each had a single branch-only tip; semantic review found only the old `5c38bdc` `shuffleTopN` behavior missing, and that outcome is ported here into the current modular live-deck implementation. The other ten tips are functionally superseded, empty, or incomplete and unwired.
+
+The split repository's remaining `codex/verify-sudden-rot` remote branch is already contained in its `main`. Remote branch deletion remains a separate, approval-gated GitHub maintenance action.
+
+## Consequences
+
+- New code, card corrections, issues, and releases belong only in `MaladumEventCards`.
+- Treat the split repository as read-only until its GitHub repository is separately archived; archiving or deletion is an external administrative action, not part of this code merge.
+- Version 2.16.1 is the first consolidated catalog version.
+- The current catalog has 142 verified rich-card records across seven game files.
+- Future extractor runs must preserve human-managed or verified records unless an explicit force-regeneration review is intended.

--- a/live-deck.js
+++ b/live-deck.js
@@ -138,7 +138,7 @@ export const liveDeckActions = {
         const actualN = Math.min(requestedN, remaining);
 
         deckState.currentDeck.splice(deckState.currentIndex, 1);
-        const insertIdx = deckState.currentIndex + Math.floor(Math.random() * actualN);
+        const insertIdx = deckState.currentIndex + 1 + Math.floor(Math.random() * actualN);
         deckState.currentDeck.splice(insertIdx, 0, card);
 
         return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maladum-event-cards",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maladum-event-cards",
-      "version": "2.16.0",
+      "version": "2.16.1",
       "devDependencies": {
         "sharp": "^0.35.3",
         "tesseract.js": "^6.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,14 +8,17 @@
       "name": "maladum-event-cards",
       "version": "2.16.0",
       "devDependencies": {
-        "sharp": "^0.34.4",
+        "sharp": "^0.35.3",
         "tesseract.js": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -34,9 +37,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -47,19 +50,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -70,19 +73,39 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -97,9 +120,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -114,9 +137,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
       ],
@@ -134,9 +157,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
       ],
@@ -154,9 +177,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
       ],
@@ -174,9 +197,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
       ],
@@ -194,9 +217,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
       ],
@@ -214,9 +237,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
       ],
@@ -234,9 +257,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
       ],
@@ -254,9 +277,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
       ],
@@ -274,9 +297,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
@@ -290,19 +313,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
       ],
@@ -316,19 +339,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
@@ -342,19 +365,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
@@ -368,19 +391,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
@@ -394,19 +417,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
       ],
@@ -420,19 +443,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
@@ -446,19 +469,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
       ],
@@ -472,39 +495,56 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
@@ -515,16 +555,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -535,16 +575,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -555,7 +595,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -631,9 +671,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -644,48 +684,53 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/tesseract.js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maladum-event-cards",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "engines": {
     "node": ">=20.9.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "maladum-event-cards",
   "version": "2.16.0",
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "test": "node tests/loadSourceModule.test.js && node tests/parseCardTypes.test.js && node tests/cardSchema.test.js && node tests/cardNormalization.test.js && node tests/cardTokenizer.test.js && node tests/cardRenderer.test.js && node tests/cardCatalogCoverage.test.js && node tests/cardSearch.test.js && node tests/cardExtraction.test.js && node tests/deckGeneration.test.js && node tests/deckRules.test.js && node tests/liveDeck.test.js && node tests/liveDeckSession.test.js && node tests/liveDeckView.test.js && node tests/deckManager.test.js && node tests/storageUtils.test.js && node tests/appSnapshot.test.js && node tests/initialization.test.js && node tests/deckFlowUtils.test.js && node tests/uiManager.test.js && node tests/events.test.js && node tests/eventsUiContract.test.js && node tests/liveDeckCss.test.js && node tests/themeCoverage.test.js && node tests/versionSync.test.js && node tests/appShellAssets.test.js && node tests/appUtils.test.js && node tests/campaignTracker.test.js && node tests/campaignPersistence.test.js && node tests/updateUtils.test.js",
     "test:cards": "node tests/parseCardTypes.test.js",
@@ -14,7 +17,7 @@
     "build": "node scripts/update-version.js"
   },
   "devDependencies": {
-    "sharp": "^0.34.4",
+    "sharp": "^0.35.3",
     "tesseract.js": "^6.0.1"
   }
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 // Unified service worker combining caching and version logic
-const APP_VERSION = '2.16.0';
+const APP_VERSION = '2.16.1';
 const CACHE_PREFIX = 'maladum-event-cards-';
 const CACHE_NAME = CACHE_PREFIX + APP_VERSION;
 
@@ -43,6 +43,7 @@ const urlsToCache = [
     './assets/icons/bludgeoning.png',
     './assets/icons/blue-reminder.svg',
     './assets/icons/camouflage.png',
+    './assets/icons/cleave.svg',
     './assets/icons/creature.png',
     './assets/icons/denizen.png',
     './assets/icons/enemy.svg',
@@ -54,6 +55,7 @@ const urlsToCache = [
     './assets/icons/grave.svg',
     './assets/icons/hawkeye.png',
     './assets/icons/health.png',
+    './assets/icons/hit-and-run.svg',
     './assets/icons/larger-area.png',
     './assets/icons/larger-area.svg',
     './assets/icons/malacytic-conduit.png',
@@ -68,15 +70,20 @@ const urlsToCache = [
     './assets/icons/piercing.png',
     './assets/icons/plunderer.png',
     './assets/icons/poison.png',
+    './assets/icons/potion.svg',
+    './assets/icons/quickstrike.svg',
     './assets/icons/red-reminder.svg',
     './assets/icons/revenant.svg',
     './assets/icons/search.svg',
     './assets/icons/sharp.png',
     './assets/icons/size.png',
     './assets/icons/skull.svg',
+    './assets/icons/sundering.svg',
     './assets/icons/unknown-icon.svg',
+    './assets/icons/vicious.svg',
     './assets/icons/wall.png',
     './assets/icons/worthy-opponent.png',
+    './assets/icons/wounded.svg',
     './assets/icons/yellow-reminder.svg',
     './assets/ui/campaign-divider.svg',
     './assets/ui/dark-surface-texture.svg',

--- a/styles.css
+++ b/styles.css
@@ -2088,35 +2088,8 @@ body {
     line-height: 1.15;
 }
 
-.card-surface__meta {
-    display: flex;
-    justify-content: center;
-    flex-wrap: wrap;
-    gap: 0.45rem;
-}
-
-.card-surface--compact .card-surface__meta,
 .card-surface--compact .card-surface__sections {
     display: none;
-}
-
-.card-meta-pill {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0.18rem 0.5rem;
-    border-radius: 999px;
-    background: rgba(40, 33, 24, 0.12);
-    border: 1px solid rgba(40, 33, 24, 0.16);
-    color: #43311d;
-    font-size: 0.72rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05rem;
-}
-
-.card-meta-pill--muted {
-    background: rgba(255, 255, 255, 0.35);
 }
 
 .card-surface__sections {
@@ -2247,6 +2220,8 @@ body {
 .card-footer-icon .card-inline-token__icon {
     width: 1.55rem;
     height: 1.55rem;
+    max-width: 1.55rem;
+    max-height: 1.55rem;
 }
 
 .card-footer-icon .card-inline-token__value {
@@ -2264,6 +2239,10 @@ body {
 .card-inline-token__icon {
     width: 1.05em;
     height: 1.05em;
+    max-width: 1.05em;
+    max-height: 1.05em;
+    flex: 0 0 auto;
+    display: block;
     object-fit: contain;
 }
 
@@ -2305,6 +2284,8 @@ body {
 .card-surface--compact .card-footer-icon .card-inline-token__icon {
     width: 1.2rem;
     height: 1.2rem;
+    max-width: 1.2rem;
+    max-height: 1.2rem;
 }
 
 .card-preview-surface {

--- a/tests/cardCatalogCoverage.test.js
+++ b/tests/cardCatalogCoverage.test.js
@@ -88,6 +88,10 @@ async function loadCatalog() {
     console.log('Testing card catalog icon coverage...');
 
     const allCards = Object.values(catalog.games).flat();
+    assert.strictEqual(allCards.length, 142,
+        'The consolidated catalog should contain all 142 reviewed cards');
+    assert(allCards.every(card => card.extraction?.status === 'verified' && card.extraction?.managedBy === 'human'),
+        'Every consolidated rich card should remain human-managed and verified');
     const unresolvedInlineTokens = [];
     const unresolvedFooterIcons = [];
 
@@ -128,13 +132,27 @@ async function loadCatalog() {
         assert(card, `Expected rich card ${id} to exist in the merged catalog`);
         return card;
     };
+    const footerTokens = card => ({
+        left: (card.footer?.left || []).map(item => item.type === 'label' ? item.text : item.name),
+        right: (card.footer?.right || []).map(item => item.type === 'label' ? item.text : item.name)
+    });
+    const sectionText = card => (card.sections || []).map(section => section.text || '').join('\n');
+    const sectionLabels = card => (card.sections || []).map(section => section.label || '').filter(Boolean);
+    const countToken = (text, token) => (String(text).match(new RegExp(`\\[${token}\\]`, 'g')) || []).length;
 
     [
         { id: 65, token: 'revenant' },
         { id: 78, token: 'blue-reminder' },
         { id: 78, token: 'red-reminder' },
         { id: 78, token: 'yellow-reminder' },
-        { id: 95, token: 'actions' }
+        { id: 95, token: 'actions' },
+        { id: 43, token: 'vicious' },
+        { id: 43, token: 'quickstrike' },
+        { id: 43, token: 'cleave' },
+        { id: 53, token: 'hit-and-run' },
+        { id: 63, token: 'potion' },
+        { id: 134, token: 'sundering' },
+        { id: 142, token: 'wounded' }
     ].forEach(({ id, token }) => {
         assert(resolveIconEntry(catalog.icons, token),
             `Card ${id} should resolve the ${token} inline token`);
@@ -152,7 +170,7 @@ async function loadCatalog() {
         });
     });
 
-    [65, 78, 95].forEach(id => {
+    [43, 53, 63, 65, 78, 95, 134, 142].forEach(id => {
         const card = cardById(id);
         const rendered = renderCardNode(card, {
             document: createDocumentStub(),
@@ -161,6 +179,111 @@ async function loadCatalog() {
         assert.strictEqual(collectByClass(rendered, 'card-inline-token--unknown').length, 0,
             `${card.card} should render without unresolved token placeholders`);
     });
+
+    {
+        const corruptTalisman = cardById(102);
+        const sectionText = corruptTalisman.sections.map(section => section.text).join('\n');
+        assert(sectionText.includes('[corrupter]'),
+            'Corrupt Talisman should use the green Corrupter token from the source card');
+        assert(!sectionText.includes('[malacytic-conduit]'),
+            'Corrupt Talisman should not use the blue Malacytic Conduit token');
+        assert.deepStrictEqual(corruptTalisman.footer.left, [{ type: 'icon', name: 'corrupter' }],
+            'Corrupt Talisman footer should use the Corrupter icon');
+        assert.strictEqual(resolveIconEntry(catalog.icons, 'corrupter')?.asset, 'logos/Corrupter.jpg',
+            'The Corrupter token should render with the green Corrupter emblem');
+    }
+
+    {
+        ['environment', 'dungeon', 'novice', 'veteran', 'malagaunt', 'wandering-beast', 'cabal', 'location']
+            .forEach(token => {
+                assert(resolveIconEntry(catalog.icons, token),
+                    `The ${token} source emblem should resolve through the icon manifest`);
+            });
+
+        assert.deepStrictEqual(footerTokens(cardById(3)).left, ['revenant'],
+            'Balefire footer should use the printed Revenant emblem, not a generic creature token');
+        assert.deepStrictEqual(footerTokens(cardById(17)).left, ['malagaunt'],
+            'Death Draws In footer should use the printed Malagaunt emblem');
+        assert.deepStrictEqual(footerTokens(cardById(50)).left, ['revenant', '+', 'veteran'],
+            'Fresh Graves footer should use the printed Revenant + Veteran emblems');
+        assert.deepStrictEqual(footerTokens(cardById(70)).left, ['dungeon', '+', 'denizen'],
+            'Heigh-Ho, Heigh-Ho! footer should use the printed Dungeon + Denizen emblems');
+        assert.deepStrictEqual(footerTokens(cardById(75)).right, ['location', 'GARRISON'],
+            'Infiltration footer should use the printed Location pin with the GARRISON label');
+        assert.deepStrictEqual(footerTokens(cardById(83)).left, ['veteran', '+', 'environment'],
+            'The Floodgates Open footer should use the printed Veteran + Environment emblems');
+        assert.deepStrictEqual(footerTokens(cardById(98)).left, ['corrupter', 'wandering-beast'],
+            'Eldritch Tentacle footer should use the printed Corrupter / Wandering Beast emblems');
+        assert.deepStrictEqual(footerTokens(cardById(98)).right, ['otherworldly'],
+            'Eldritch Tentacle footer should use the printed Otherworldly emblem on the right');
+        assert.deepStrictEqual(footerTokens(cardById(114)).left, ['cabal'],
+            'The Cabal footer should use the printed Cabal emblem');
+    }
+
+    {
+        const artificialLabels = new Set(['NPC Activation Rules', 'Character Rules', 'Note', 'Body', '(body)']);
+        const dreadLabel = /^(?:DISQUIET|DISTRESS|DISMAY|DESPERATION|DISASTER|DOOM)(?:-(?:DISQUIET|DISTRESS|DISMAY|DESPERATION|DISASTER|DOOM))*$/;
+
+        allCards.forEach(card => {
+            (card.sections || []).forEach(section => {
+                assert(!('threshold' in section),
+                    `${card.card} should not render unprinted numeric section thresholds`);
+                assert(!artificialLabels.has(section.label),
+                    `${card.card} should not render an invented section label`);
+                if (section.label && dreadLabel.test(section.label.toUpperCase())) {
+                    assert(dreadLabel.test(section.label),
+                        `${card.card} mode label should match printed uppercase styling: ${section.label}`);
+                }
+            });
+        });
+    }
+
+    {
+        const blaze = sectionText(cardById(43));
+        assert(blaze.includes('Vicious [vicious], Quickstrike [quickstrike], and Cleave [cleave]'),
+            'Blaze of Glory should use the printed Vicious, Quickstrike, and Cleave icons');
+        assert(!blaze.includes('Vicious [sharp]') && !blaze.includes('Quickstrike [move]') && !blaze.includes('Cleave [melee]'),
+            'Blaze of Glory should not use generic rule icons for named abilities');
+
+        assert(sectionText(cardById(53)).includes('Hit and Run [hit-and-run]'),
+            'Stand And Deliver! should use the printed Hit and Run icon');
+        assert.deepStrictEqual(sectionLabels(cardById(54)), ['DISQUIET-DOOM'],
+            'Bounty! should not render its title as an extra section label');
+        assert(sectionText(cardById(56)).includes('gains G20.'),
+            'Excursionist should render the printed G20 reward text');
+        assert(sectionText(cardById(63)).includes('Potion [potion] of your choice'),
+            'Stroke Of Fortune should include the printed potion icon');
+
+        assert(sectionText(cardById(67)).includes('Poisoned [poison] counter'),
+            'Toxic Waste should include the printed poisoned counter token');
+        assert(sectionText(cardById(74)).includes('Adventurers may Interact'),
+            'Nectar Of The Gods should preserve printed Interact capitalization');
+
+        assert(sectionText(cardById(96)).includes('Take all [wandering-beast] cards'),
+            'Home Invasion should use the printed Wandering Beast card icon');
+        assert(sectionText(cardById(97)).includes('Resolve it immediately.'),
+            'Unmasked! should not retain the OCR typo');
+        assert.strictEqual(cardById(113).card, 'Maladite Golem',
+            'Maladite Golem should use the printed card title');
+
+        assert(sectionText(cardById(134)).includes('Sundering [sundering]'),
+            'Malacytic Vigour should include the printed Sundering icon');
+        assert(sectionText(cardById(135)).includes('Sundering [sundering]'),
+            'Trap! Deadfall should include the printed Sundering icon');
+        assert(sectionText(cardById(139)).includes('Déjà vu'),
+            'Not Again? should preserve the printed accent');
+        assert.strictEqual(countToken(sectionText(cardById(142)), 'wounded'), 2,
+            'Trap! Caltrops should include both printed Wounded icons');
+
+        const suddenRot = cardById(133);
+        assert.strictEqual(suddenRot.extraction.status, 'verified',
+            'Sudden Rot should be verified once the printed food item list is captured');
+        assert(!sectionText(suddenRot).includes('[unknown-icon]'),
+            'Sudden Rot should not keep unresolved placeholders after food item review');
+        ['Morsel', 'Provisions', 'Remedy', 'Minerals', 'Sunblessed Weed', 'Herbs', 'Fungus'].forEach(item => {
+            assert(sectionText(suddenRot).includes(item), `Sudden Rot should list ${item} as food`);
+        });
+    }
 
     console.log('All card catalog coverage tests passed!');
 })().catch(error => {

--- a/tests/cardRenderer.test.js
+++ b/tests/cardRenderer.test.js
@@ -75,6 +75,19 @@ function collectByClass(node, className, matches = []) {
     return matches;
 }
 
+function collectVisibleText(node, values = []) {
+    if (!node || typeof node !== 'object') {
+        return values;
+    }
+
+    if (node.textContent && (!node.children || node.children.length === 0)) {
+        values.push(node.textContent);
+    }
+
+    (node.children || []).forEach(child => collectVisibleText(child, values));
+    return values;
+}
+
 (async () => {
     const {
         renderCardNode,
@@ -120,8 +133,12 @@ function collectByClass(node, className, matches = []) {
         iconRegistry
     });
 
-    assert.strictEqual(collectByClass(fullNode, 'card-surface__meta').length, 1,
-        'Full cards should include metadata pills');
+    assert.strictEqual(collectByClass(fullNode, 'card-surface__meta').length, 0,
+        'Full cards should not insert metadata into the printed-card text flow');
+    assert.deepStrictEqual(collectVisibleText(fullNode).slice(0, 2), [
+        'Heigh-Ho, Heigh-Ho!',
+        'DISQUIET-DISMAY'
+    ], 'Full cards should place the first section label immediately after the title');
     assert.strictEqual(collectByClass(fullNode, 'card-section').length, 1,
         'Full cards should include rendered body sections');
     assert.strictEqual(collectByClass(fullNode, 'card-footer-icon').length, 3,

--- a/tests/cardSearch.test.js
+++ b/tests/cardSearch.test.js
@@ -40,6 +40,18 @@ async function loadModule(relativePath) {
                     text: 'Increase the Dread by 1.'
                 }
             ]
+        }, 'Base Game', 'legacy'),
+        normalizeCard({
+            id: 139,
+            card: 'Not Again?',
+            type: 'Veteran',
+            contents: 'Not_Again.png',
+            sections: [
+                {
+                    header: 'DISQUIET-DOOM',
+                    text: 'You are overcome with an uneasy feeling of Déjà vu and impending doom.'
+                }
+            ]
         }, 'Base Game', 'legacy')
     ];
 
@@ -49,6 +61,9 @@ async function loadModule(relativePath) {
 
     const titleMatches = searchCards(cards, 'alarm');
     assert.strictEqual(titleMatches[0].id, 51, 'Title search behavior should still work');
+
+    const accentMatches = searchCards(cards, 'deja');
+    assert.strictEqual(accentMatches[0].id, 139, 'ASCII search should match accented card text');
 
     const repositoryRoot = path.join(__dirname, '..');
     const manifest = JSON.parse(fs.readFileSync(
@@ -68,8 +83,8 @@ async function loadModule(relativePath) {
     const productionRulesMatches = searchCards(productionCards, 'odour decaying');
     const suddenRot = productionRulesMatches.find(card => card.card === 'Sudden Rot');
     assert(suddenRot, 'Production search should find Sudden Rot from its rules text');
-    assert.strictEqual(suddenRot.renderMode, 'image',
-        'The incomplete Sudden Rot record should stay searchable while using its source image');
+    assert.strictEqual(suddenRot.renderMode, 'rich',
+        'The verified Sudden Rot record should render from its reconciled structured text');
 
     console.log('All structured card search tests passed!');
 })().catch(error => {

--- a/tests/deckRules.test.js
+++ b/tests/deckRules.test.js
@@ -61,11 +61,40 @@ console.log('Testing deck rules...');
         { id: 102, card: 'Corrupter E', type: 'Corrupter', contents: 'ce.png' }
     ];
 
-    const result = buildDeck({
+    [0, 1, 5].forEach(configuredCount => {
+        const result = buildDeck({
+            allCardTypes: ['Denizen', 'Corrupter'],
+            availableCards: cards,
+            deckDataByType: {
+                Denizen: cards.slice(0, 5),
+                Corrupter: cards.slice(5)
+            },
+            dataStore: {
+                sentryTypes: [],
+                corrupterTypes: ['Corrupter'],
+                heldBackCardTypes: []
+            },
+            enableCorrupterRules: true,
+            cardCounts: { Denizen: 5 },
+            specialCardCounts: { Corrupter: configuredCount },
+            corrupterReplacementCount: 5
+        });
+
+        const corrupterIds = result.combinedDeck
+            .filter(card => card.type === 'Corrupter')
+            .map(card => card.id);
+
+        assert.strictEqual(result.combinedDeck.length, 5);
+        assert.strictEqual(corrupterIds.length, 5,
+            `Corrupter rules should replace five cards when the configured count is ${configuredCount}`);
+        assert.strictEqual(new Set(corrupterIds).size, 5);
+    });
+
+    const shortDeck = buildDeck({
         allCardTypes: ['Denizen', 'Corrupter'],
         availableCards: cards,
         deckDataByType: {
-            Denizen: cards.slice(0, 5),
+            Denizen: cards.slice(0, 4),
             Corrupter: cards.slice(5)
         },
         dataStore: {
@@ -74,18 +103,14 @@ console.log('Testing deck rules...');
             heldBackCardTypes: []
         },
         enableCorrupterRules: true,
-        cardCounts: { Denizen: 5 },
+        cardCounts: { Denizen: 4 },
         specialCardCounts: { Corrupter: 5 },
         corrupterReplacementCount: 5
     });
 
-    const corrupterIds = result.combinedDeck
-        .filter(card => card.type === 'Corrupter')
-        .map(card => card.id);
-
-    assert.strictEqual(result.combinedDeck.length, 5);
-    assert.strictEqual(corrupterIds.length, 5);
-    assert.strictEqual(new Set(corrupterIds).size, 5);
+    assert.strictEqual(shortDeck.combinedDeck.length, 4,
+        'Corrupter cards should not be appended when the main deck is too short for replacement');
+    assert.strictEqual(shortDeck.combinedDeck.some(card => card.type === 'Corrupter'), false);
 }
 
 {
@@ -102,6 +127,28 @@ console.log('Testing deck rules...');
     });
 
     assert.strictEqual(result.error, DECK_RULE_ERRORS.emptySelection);
+}
+
+{
+    const { buildDeck, DECK_RULE_ERRORS } = loadDeckRules();
+    const result = buildDeck({
+        allCardTypes: ['Corrupter'],
+        availableCards: [{ id: 98, card: 'Corrupter A', type: 'Corrupter' }],
+        deckDataByType: {
+            Corrupter: [{ id: 98, card: 'Corrupter A', type: 'Corrupter' }]
+        },
+        dataStore: {
+            sentryTypes: [],
+            corrupterTypes: ['Corrupter'],
+            heldBackCardTypes: []
+        },
+        enableCorrupterRules: true,
+        specialCardCounts: { Corrupter: 5 },
+        corrupterReplacementCount: 5
+    });
+
+    assert.strictEqual(result.error, DECK_RULE_ERRORS.emptySelection,
+        'Corrupter rules require a regular or Sentry selection to build a deck');
 }
 
 console.log('All deck rules tests passed!');

--- a/tests/liveDeck.test.js
+++ b/tests/liveDeck.test.js
@@ -123,14 +123,16 @@ console.log('Testing live deck transitions...');
     const originalRandom = Math.random;
 
     try {
-        Math.random = () => 0.999;
+        Math.random = () => 0;
         const result = liveDeckActions.shuffleTopN(state, activeCard, 2);
         const newIndex = state.currentDeck.findIndex(card => card.id === activeCard.id);
 
         assert.strictEqual(result.message.includes('next 2 cards'), true);
         assert.strictEqual(result.render, true);
-        assert(newIndex >= state.currentIndex && newIndex <= state.currentIndex + 1,
-            'shuffleTopN should insert within the next N cards');
+        assert.strictEqual(newIndex, state.currentIndex + 1,
+            'shuffleTopN should insert after the newly revealed next card');
+        assert.strictEqual(state.currentDeck[state.currentIndex].id, 3,
+            'shuffleTopN should reveal the card that originally followed the active card');
     } finally {
         Math.random = originalRandom;
     }

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "2.16.0",
-  "lastUpdated": "2026-07-18"
+  "version": "2.16.1",
+  "lastUpdated": "2026-08-14"
 }


### PR DESCRIPTION
## What changed
Consolidates the reviewed rich event-card work into the canonical repository, retaining the required shuffle behavior and printed-card rendering decisions.

## Why
This completes the approved move from the donor repository while keeping the canonical repository as the single source of truth.

## Validation
Full tests, card validation, build idempotence, and git diff --check passed before publication.